### PR TITLE
chore(der): tighten up DerReader security

### DIFF
--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/Der.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/Der.kt
@@ -58,11 +58,22 @@ class DerWriter {
     fun integer(i: BigInteger) {
         writeTag(0x02, i.toByteArray())
     }
-    
+
+    fun bitString(bytes: ByteArray) {
+        val content = ByteArray(1 + bytes.size)
+        content[0] = 0x00 // zero unused bits
+        System.arraycopy(bytes, 0, content, 1, bytes.size)
+        writeTag(0x03, content)
+    }
+
     fun octetString(bytes: ByteArray) {
         writeTag(0x04, bytes)
     }
-    
+
+    fun objectIdentifier(oid: ByteArray) {
+        writeTag(0x06, oid)
+    }
+
     fun nullValue() {
         buffer.write(0x05)
         buffer.write(0x00)
@@ -105,26 +116,36 @@ class DerWriter {
 class DerReader(private val data: ByteBuffer) {
     constructor(bytes: ByteArray) : this(ByteBuffer.wrap(bytes))
 
-    fun readSequence(block: (DerReader) -> Unit) {
+    fun <T> readSequence(block: (DerReader) -> T): T {
         val tag = data.get().toInt() and 0xFF
         if (tag != 0x30) {
             throw SshException("Expected SEQUENCE (0x30) but got 0x${tag.toString(16)}")
         }
         val length = readLength()
         val end = data.position() + length
-        
+
         // Create a limit slice for the sequence content
         val oldLimit = data.limit()
         data.limit(end)
-        
+
         try {
-            block(this)
+            val result = block(this)
+            if (data.position() != end) {
+                throw SshException("SEQUENCE has ${end - data.position()} unconsumed bytes")
+            }
+            return result
         } finally {
             data.limit(oldLimit)
             data.position(end)
         }
     }
-    
+
+    fun ensureFullyConsumed() {
+        if (data.hasRemaining()) {
+            throw SshException("${data.remaining()} trailing bytes after DER data")
+        }
+    }
+
     fun readInteger(): BigInteger {
         val tag = data.get().toInt() and 0xFF
         if (tag != 0x02) {

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/Ed25519SignatureAlgorithm.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/Ed25519SignatureAlgorithm.kt
@@ -25,14 +25,20 @@ import java.security.Signature
 import java.security.spec.X509EncodedKeySpec
 
 object Ed25519SignatureAlgorithm : SshSignatureAlgorithm {
+    private val ED25519_OID = byteArrayOf(0x2b, 0x65, 0x70) // 1.3.101.112
+
     override fun verify(pubKey: SshPublicKey, sig: SshSignature, data: ByteArray): Boolean {
         val keyBlob = pubKey.keyBlob() as SshEd25519PublicKeyBlob
         val rawKey = keyBlob.key().data()
 
-        val x509Prefix = byteArrayOf(
-            0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00
-        )
-        val x509Key = x509Prefix + rawKey
+        val x509Key = encodeDer {
+            sequence {
+                sequence {
+                    objectIdentifier(ED25519_OID)
+                }
+                bitString(rawKey)
+            }
+        }
         val keySpec = X509EncodedKeySpec(x509Key)
         val jcaKey = KeyFactory.getInstance("Ed25519").generatePublic(keySpec)
 

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/DerTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/DerTest.kt
@@ -16,10 +16,12 @@
 
 package org.connectbot.sshlib.crypto
 
+import org.connectbot.sshlib.SshException
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.math.BigInteger
+import kotlin.test.assertFailsWith
 
 class DerTest {
 
@@ -65,12 +67,39 @@ class DerTest {
     fun testReader() {
         val data = byteArrayOf(0x30, 0x06, 0x02, 0x01, 0x0A, 0x02, 0x01, 0x14)
         val reader = DerReader(data)
-        
+
         reader.readSequence { seq ->
             val v1 = seq.readInteger()
             val v2 = seq.readInteger()
             assertEquals(BigInteger.valueOf(10), v1)
             assertEquals(BigInteger.valueOf(20), v2)
+        }
+        reader.ensureFullyConsumed()
+    }
+
+    @Test
+    fun `rejects trailing bytes after DER data`() {
+        val data = byteArrayOf(0x30, 0x03, 0x02, 0x01, 0x0A, 0xFF.toByte())
+        val reader = DerReader(data)
+
+        reader.readSequence { seq ->
+            seq.readInteger()
+        }
+        assertFailsWith<SshException> {
+            reader.ensureFullyConsumed()
+        }
+    }
+
+    @Test
+    fun `rejects unconsumed bytes inside sequence`() {
+        // SEQUENCE length says 4 bytes, but only one INTEGER (3 bytes) is read
+        val data = byteArrayOf(0x30, 0x04, 0x02, 0x01, 0x0A, 0xFF.toByte())
+        val reader = DerReader(data)
+
+        assertFailsWith<SshException> {
+            reader.readSequence { seq ->
+                seq.readInteger()
+            }
         }
     }
 }

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/EcdsaSignatureAlgorithmTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/EcdsaSignatureAlgorithmTest.kt
@@ -78,18 +78,10 @@ class EcdsaSignatureAlgorithmTest {
     }
 
     private fun parseDerEcdsaSignature(der: ByteArray): Pair<BigInteger, BigInteger> {
-        var offset = 2
-        if (der[1].toInt() and 0x80 != 0) {
-            offset = 2 + (der[1].toInt() and 0x7f)
+        val reader = DerReader(der)
+        return reader.readSequence { seq ->
+            seq.readInteger() to seq.readInteger()
         }
-        assert(der[offset] == 0x02.toByte())
-        val rLen = der[offset + 1].toInt() and 0xff
-        val r = BigInteger(1, der.copyOfRange(offset + 2, offset + 2 + rLen))
-        offset += 2 + rLen
-        assert(der[offset] == 0x02.toByte())
-        val sLen = der[offset + 1].toInt() and 0xff
-        val s = BigInteger(1, der.copyOfRange(offset + 2, offset + 2 + sLen))
-        return Pair(r, s)
     }
 
     private fun parse(hostKey: ByteArray, sshSig: ByteArray): Pair<SshPublicKey, SshSignature> {


### PR DESCRIPTION
Throw error when the sequence was not fully consumed.