### PR TITLE
feat(crypto): port over ML-KEX and Curve25519

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ that runs in reaction to state changes.
 - `ssh-rsa` ([RFC 4253](https://tools.ietf.org/html/rfc4253#section-8.1))
 
 ### Key Exchange
+- `mlkem768x25519-sha256` ([draft-ietf-sshm-mlkem-hybrid-kex](https://datatracker.ietf.org/doc/draft-ietf-sshm-mlkem-hybrid-kex/) (depends on JEP-496 support)
+- `curve25519-sha256` ([RFC 8731](https://tools.ietf.org/html/rfc8731))
 - `ecdh-sha2-nistp521` ([RFC 5656](https://tools.ietf.org/html/rfc5656#section-4))
 - `ecdh-sha2-nistp384` ([RFC 5656](https://tools.ietf.org/html/rfc5656#section-4))
 - `ecdh-sha2-nistp256` ([RFC 5656](https://tools.ietf.org/html/rfc5656#section-4))
@@ -50,6 +52,7 @@ that runs in reaction to state changes.
 - `diffie-hellman-group1-sha1` ([RFC 4253](https://tools.ietf.org/html/rfc4253#section-8.1))
 
 ### Encryption
+- `chacha20-poly1305@openssh.com` ([draft-ietf-sshm-chacha20-poly1305](https://datatracker.ietf.org/doc/html/draft-ietf-sshm-chacha20-poly1305))
 - `aes256-gcm@openssh.com` ([draft-miller-sshm-aes-gcm](https://datatracker.ietf.org/doc/html/draft-miller-sshm-aes-gcm))
 - `aes128-gcm@openssh.com` ([draft-miller-sshm-aes-gcm](https://datatracker.ietf.org/doc/html/draft-miller-sshm-aes-gcm))
 - `aes256-ctr` ([RFC 4344](https://tools.ietf.org/html/rfc4344#section-4))

--- a/sshlib/build.gradle.kts
+++ b/sshlib/build.gradle.kts
@@ -85,6 +85,8 @@ dependencies {
     implementation("io.github.nsk90:kstatemachine-jvm:0.36.0")
     implementation("io.ktor:ktor-network:3.4.0")
     implementation("org.slf4j:slf4j-api:2.0.17")
+    implementation("com.google.crypto.tink:tink:1.20.0")
+    implementation("asia.hombre:kyber:2.0.1")
 
     // Unit tests
     testImplementation("junit:junit:4.13.2")

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
@@ -644,8 +644,8 @@ class SshConnection(
 
         val c2sKey = keys.encryptionKeyClientToServer.copyOf(entryC2S.keyLength)
         val s2cKey = keys.encryptionKeyServerToClient.copyOf(entryS2C.keyLength)
-        val c2sIv = keys.initialIvClientToServer.copyOf(entryC2S.ivLength)
-        val s2cIv = keys.initialIvServerToClient.copyOf(entryS2C.ivLength)
+        val c2sIv = if (entryC2S.ivLength > 0) keys.initialIvClientToServer.copyOf(entryC2S.ivLength) else ByteArray(0)
+        val s2cIv = if (entryS2C.ivLength > 0) keys.initialIvServerToClient.copyOf(entryS2C.ivLength) else ByteArray(0)
 
         val c2sAead = (entryC2S.create(c2sKey, c2sIv, true) as EncryptionInstance.Aead).aead
         val s2cAead = (entryS2C.create(s2cKey, s2cIv, false) as EncryptionInstance.Aead).aead

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/Algorithms.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/Algorithms.kt
@@ -29,6 +29,10 @@ enum class CipherEntry(
     val isAead: Boolean,
     private val factory: (key: ByteArray, iv: ByteArray, forEncryption: Boolean) -> EncryptionInstance
 ) {
+    CHACHA20_POLY1305(
+        "chacha20-poly1305@openssh.com", 64, 0, 8, true,
+        { key, _, _ -> EncryptionInstance.Aead(ChaCha20Poly1305Cipher(key)) }
+    ),
     AES128_GCM(
         "aes128-gcm@openssh.com", 16, 12, 16, true,
         { key, iv, _ -> EncryptionInstance.Aead(AesGcmCipher(key, iv)) }
@@ -123,6 +127,14 @@ enum class KexEntry(
     val type: KexType,
     private val factory: () -> KexAlgorithm
 ) {
+    MLKEM768X25519_SHA256(
+        "mlkem768x25519-sha256", "SHA-256", KexType.ECDH,
+        { MlKemHybridKeyExchange() }
+    ),
+    CURVE25519_SHA256(
+        "curve25519-sha256", "SHA-256", KexType.ECDH,
+        { Curve25519KeyExchange() }
+    ),
     ECDH_SHA2_NISTP256(
         "ecdh-sha2-nistp256", "SHA-256", KexType.ECDH,
         { EcdhKeyExchange("nistp256") }

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/ChaCha20ParamFactory.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/ChaCha20ParamFactory.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import java.lang.reflect.Constructor
+import java.security.spec.AlgorithmParameterSpec
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+internal object ChaCha20ParamFactory {
+    private val usesChaCha20ParameterSpec: Boolean
+    private val constructor: Constructor<*>?
+
+    init {
+        var ctor: Constructor<*>? = null
+        var useSpec = false
+
+        try {
+            val clazz = Class.forName("javax.crypto.spec.ChaCha20ParameterSpec")
+            ctor = clazz.getConstructor(ByteArray::class.java, Int::class.javaPrimitiveType)
+
+            val testNonce = ByteArray(12)
+            val testKey = ByteArray(32)
+            val testParams = ctor.newInstance(testNonce, 0) as AlgorithmParameterSpec
+            val testKeySpec = SecretKeySpec(testKey, "ChaCha20")
+
+            val testCipher = Cipher.getInstance("ChaCha20")
+            testCipher.init(Cipher.DECRYPT_MODE, testKeySpec, testParams)
+
+            useSpec = true
+        } catch (_: Exception) {
+        }
+
+        usesChaCha20ParameterSpec = useSpec
+        constructor = if (useSpec) ctor else null
+    }
+
+    fun create(nonce: ByteArray, counter: Int): AlgorithmParameterSpec {
+        if (usesChaCha20ParameterSpec && constructor != null) {
+            return constructor.newInstance(nonce.clone(), counter) as AlgorithmParameterSpec
+        }
+        return IvParameterSpec(nonce.clone())
+    }
+
+    fun usesChaCha20ParameterSpec(): Boolean = usesChaCha20ParameterSpec
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/ChaCha20Poly1305Cipher.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/ChaCha20Poly1305Cipher.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import org.connectbot.sshlib.transport.TransportException
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * ChaCha20-Poly1305 AEAD cipher for SSH (chacha20-poly1305@openssh.com).
+ *
+ * Uses two separate ChaCha20 instances:
+ * - K_1 (first 32 bytes): encrypts payload, generates Poly1305 key
+ * - K_2 (second 32 bytes): encrypts packet length field
+ *
+ * The Poly1305 tag covers encrypted_length || ciphertext.
+ */
+class ChaCha20Poly1305Cipher(key: ByteArray) : PacketAead {
+    companion object {
+        const val KEY_SIZE = 64
+        const val TAG_SIZE = 16
+        const val BLOCK_SIZE = 8
+    }
+
+    override val tagLength: Int = TAG_SIZE
+    override val encryptsLength: Boolean = true
+
+    private val mainKeySpec: SecretKeySpec
+    private val headerKeySpec: SecretKeySpec
+
+    private val headerCipher: Cipher
+    private val polyKeyCipher: Cipher
+    private val payloadCipher: Cipher
+
+    private val poly = Poly1305()
+
+    private val nonce = ByteArray(12)
+    private val polyKeyZeros = ByteArray(32)
+    private val polyKey = ByteArray(32)
+    private val computedTag = ByteArray(TAG_SIZE)
+    private val skipToNextBlock = ByteArray(64)
+
+    init {
+        require(key.size == KEY_SIZE) { "ChaCha20-Poly1305 requires 64 bytes of key material" }
+
+        mainKeySpec = SecretKeySpec(key, 0, 32, "ChaCha20")
+        headerKeySpec = SecretKeySpec(key, 32, 32, "ChaCha20")
+
+        headerCipher = Cipher.getInstance("ChaCha20")
+        polyKeyCipher = Cipher.getInstance("ChaCha20")
+        payloadCipher = Cipher.getInstance("ChaCha20")
+    }
+
+    private fun updateNonce(seqNum: Long) {
+        nonce[8] = (seqNum ushr 24).toByte()
+        nonce[9] = (seqNum ushr 16).toByte()
+        nonce[10] = (seqNum ushr 8).toByte()
+        nonce[11] = seqNum.toByte()
+    }
+
+    override fun encryptLength(sequenceNumber: Long, plainLength: ByteArray): ByteArray {
+        updateNonce(sequenceNumber)
+        val params = ChaCha20ParamFactory.create(nonce, 0)
+        headerCipher.init(Cipher.ENCRYPT_MODE, headerKeySpec, params)
+        val dest = ByteArray(4)
+        headerCipher.doFinal(plainLength, 0, 4, dest, 0)
+        return dest
+    }
+
+    override fun decryptLength(sequenceNumber: Long, encryptedLength: ByteArray): ByteArray {
+        updateNonce(sequenceNumber)
+        val params = ChaCha20ParamFactory.create(nonce, 0)
+        headerCipher.init(Cipher.DECRYPT_MODE, headerKeySpec, params)
+        val dest = ByteArray(4)
+        headerCipher.doFinal(encryptedLength, 0, 4, dest, 0)
+        return dest
+    }
+
+    override fun encrypt(packetLength: ByteArray, plaintext: ByteArray): AeadResult {
+        // Note: nonce already set by encryptLength() for the same sequence number
+        val ciphertext = ByteArray(plaintext.size)
+        val tag = ByteArray(TAG_SIZE)
+
+        if (ChaCha20ParamFactory.usesChaCha20ParameterSpec()) {
+            val polyKeyParams = ChaCha20ParamFactory.create(nonce, 0)
+            polyKeyCipher.init(Cipher.ENCRYPT_MODE, mainKeySpec, polyKeyParams)
+            polyKeyCipher.doFinal(polyKeyZeros, 0, 32, polyKey, 0)
+
+            val payloadParams = ChaCha20ParamFactory.create(nonce, 1)
+            payloadCipher.init(Cipher.ENCRYPT_MODE, mainKeySpec, payloadParams)
+            payloadCipher.doFinal(plaintext, 0, plaintext.size, ciphertext, 0)
+        } else {
+            val params = ChaCha20ParamFactory.create(nonce, 0)
+            payloadCipher.init(Cipher.ENCRYPT_MODE, mainKeySpec, params)
+            payloadCipher.update(polyKeyZeros, 0, 32, polyKey, 0)
+            payloadCipher.update(skipToNextBlock, 0, 32, skipToNextBlock, 0)
+            payloadCipher.doFinal(plaintext, 0, plaintext.size, ciphertext, 0)
+        }
+
+        poly.init(polyKey)
+        poly.update(packetLength, 0, 4)
+        poly.update(ciphertext, 0, ciphertext.size)
+        poly.finish(tag, 0)
+
+        polyKey.fill(0)
+
+        return AeadResult(ciphertext, tag)
+    }
+
+    override fun decrypt(packetLength: ByteArray, ciphertext: ByteArray, tag: ByteArray): ByteArray {
+        // Note: nonce already set by decryptLength() for the same sequence number
+        if (ChaCha20ParamFactory.usesChaCha20ParameterSpec()) {
+            val polyKeyParams = ChaCha20ParamFactory.create(nonce, 0)
+            polyKeyCipher.init(Cipher.ENCRYPT_MODE, mainKeySpec, polyKeyParams)
+            polyKeyCipher.doFinal(polyKeyZeros, 0, 32, polyKey, 0)
+        } else {
+            val params = ChaCha20ParamFactory.create(nonce, 0)
+            payloadCipher.init(Cipher.ENCRYPT_MODE, mainKeySpec, params)
+            payloadCipher.update(polyKeyZeros, 0, 32, polyKey, 0)
+        }
+
+        poly.init(polyKey)
+        poly.update(packetLength, 0, 4)
+        poly.update(ciphertext, 0, ciphertext.size)
+        poly.finish(computedTag, 0)
+
+        val tagValid = constantTimeEquals(tag, computedTag)
+        computedTag.fill(0)
+        polyKey.fill(0)
+
+        if (!tagValid) {
+            throw TransportException("ChaCha20-Poly1305 authentication failed")
+        }
+
+        val plaintext = ByteArray(ciphertext.size)
+        if (ChaCha20ParamFactory.usesChaCha20ParameterSpec()) {
+            val payloadParams = ChaCha20ParamFactory.create(nonce, 1)
+            payloadCipher.init(Cipher.ENCRYPT_MODE, mainKeySpec, payloadParams)
+            payloadCipher.doFinal(ciphertext, 0, ciphertext.size, plaintext, 0)
+        } else {
+            // For IvParameterSpec path, cipher was already initialized in polyKey generation
+            payloadCipher.update(skipToNextBlock, 0, 32, skipToNextBlock, 0)
+            payloadCipher.doFinal(ciphertext, 0, ciphertext.size, plaintext, 0)
+        }
+
+        return plaintext
+    }
+
+    private fun constantTimeEquals(a: ByteArray, b: ByteArray): Boolean {
+        if (a.size != b.size) return false
+        var result = 0
+        for (i in a.indices) {
+            result = result or (a[i].toInt() xor b[i].toInt())
+        }
+        return result == 0
+    }
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/Curve25519KeyExchange.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/Curve25519KeyExchange.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import org.connectbot.sshlib.SshException
+import java.math.BigInteger
+
+class Curve25519KeyExchange(
+    private val x25519Provider: X25519Provider = X25519ProviderFactory.provider,
+    private val presetPrivateKey: ByteArray? = null
+) : KexAlgorithm {
+
+    override val hashAlgorithm: String = "SHA-256"
+
+    private var clientPrivate: ByteArray? = null
+
+    override fun generateClientKeys(): ByteArray {
+        clientPrivate = presetPrivateKey?.clone() ?: x25519Provider.generatePrivateKey()
+        return try {
+            x25519Provider.publicFromPrivate(clientPrivate!!)
+        } catch (e: Exception) {
+            throw SshException("Failed to generate X25519 public key", e)
+        }
+    }
+
+    override fun computeSharedSecret(serverPublicKey: ByteArray): ByteArray {
+        val privKey = clientPrivate
+            ?: throw SshException("Client keys not generated; call generateClientKeys() first")
+
+        if (serverPublicKey.size != X25519Provider.KEY_SIZE) {
+            throw SshException(
+                "Invalid server key length ${serverPublicKey.size} (expected ${X25519Provider.KEY_SIZE})"
+            )
+        }
+
+        try {
+            val sharedSecretBytes = x25519Provider.computeSharedSecret(privKey, serverPublicKey)
+
+            var allZero = true
+            for (b in sharedSecretBytes) {
+                if (b.toInt() != 0) {
+                    allZero = false
+                    break
+                }
+            }
+            if (allZero) {
+                throw SshException("Invalid key computed; all zeroes")
+            }
+
+            return encodeMpint(BigInteger(1, sharedSecretBytes).toByteArray())
+        } catch (e: SshException) {
+            throw e
+        } catch (e: Exception) {
+            throw SshException("X25519 key agreement failed", e)
+        }
+    }
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/DiffieHellman.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/DiffieHellman.kt
@@ -53,6 +53,6 @@ class DiffieHellman(
             throw SshException("Invalid server public key")
         }
 
-        return f.modPow(x, p).toByteArray()
+        return encodeMpint(f.modPow(x, p).toByteArray())
     }
 }

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/DiffieHellmanGroupExchange.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/DiffieHellmanGroupExchange.kt
@@ -66,7 +66,7 @@ class DiffieHellmanGroupExchange(override val hashAlgorithm: String) : KexAlgori
             throw SshException("Invalid server public key")
         }
 
-        return f.modPow(x, p).toByteArray()
+        return encodeMpint(f.modPow(x, p).toByteArray())
     }
 
     /**
@@ -121,7 +121,7 @@ class DiffieHellmanGroupExchange(override val hashAlgorithm: String) : KexAlgori
         writeString(g.toByteArray())
         writeString(clientPublicKey)
         writeString(serverPublicKey)
-        writeString(sharedSecret)
+        transcript.write(sharedSecret)
 
         val md = MessageDigest.getInstance(hashAlgorithm)
         return md.digest(transcript.toByteArray())

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/EcdhKeyExchange.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/EcdhKeyExchange.kt
@@ -92,7 +92,7 @@ class EcdhKeyExchange(private val curveName: String) : KexAlgorithm {
             agreement.doPhase(serverPubKey, true)
             val rawSecret = agreement.generateSecret()
 
-            return BigInteger(1, rawSecret).toByteArray()
+            return encodeMpint(BigInteger(1, rawSecret).toByteArray())
         } catch (e: SshException) {
             throw e
         } catch (e: Exception) {

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/JavaMlKemProvider.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/JavaMlKemProvider.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import java.io.IOException
+import java.security.KeyFactory
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.X509EncodedKeySpec
+
+/**
+ * ML-KEM provider using Java 23+ native javax.crypto.KEM API via reflection.
+ */
+class JavaMlKemProvider : MlKemProvider {
+    companion object {
+        private const val MLKEM768_PUBLIC_KEY_SIZE = 1184
+
+        // X.509 wrapper for ML-KEM-768 public keys
+        private val X509_PREFIX = byteArrayOf(
+            0x30, 0x82.toByte(), 0x04, 0xb2.toByte(),  // SEQUENCE
+            0x30, 0x0b,                                 // SEQUENCE
+            0x06, 0x09,                                 // OID
+            0x60, 0x86.toByte(), 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x02,
+            0x03, 0x82.toByte(), 0x04, 0xa1.toByte(),   // BIT STRING
+            0x00                                        // no unused bits
+        )
+    }
+
+    private val kemInstance: Any
+
+    init {
+        try {
+            val kemClass = Class.forName("javax.crypto.KEM")
+            val getInstance = kemClass.getMethod("getInstance", String::class.java)
+            kemInstance = getInstance.invoke(null, "ML-KEM")
+        } catch (e: Exception) {
+            throw IOException("Failed to initialize Java KEM API", e)
+        }
+    }
+
+    override fun generateKeyPair(): MlKemKeyPair {
+        try {
+            val kpg = KeyPairGenerator.getInstance("ML-KEM-768")
+            val keyPair = kpg.generateKeyPair()
+
+            val x509PublicKey = keyPair.public.encoded
+            val pkcs8PrivateKey = keyPair.private.encoded
+
+            val rawPublicKey = extractRawMlKemPublicKey(x509PublicKey)
+            return MlKemKeyPair(rawPublicKey, pkcs8PrivateKey)
+        } catch (e: Exception) {
+            throw IOException("ML-KEM-768 key generation failed", e)
+        }
+    }
+
+    override fun encapsulate(publicKey: ByteArray): MlKemEncapsulationResult {
+        try {
+            val x509Encoded = wrapRawMlKemPublicKey(publicKey)
+            val kf = KeyFactory.getInstance("ML-KEM")
+            val pubKey = kf.generatePublic(X509EncodedKeySpec(x509Encoded))
+
+            val kemClass = Class.forName("javax.crypto.KEM")
+            val newEncapsulator = kemClass.getMethod("newEncapsulator", java.security.PublicKey::class.java)
+            val encapsulator = newEncapsulator.invoke(kemInstance, pubKey)
+
+            val encapsulatorClass = Class.forName("javax.crypto.KEM\$Encapsulator")
+            val encapsulateMethod = encapsulatorClass.getMethod("encapsulate")
+            val encapsulated = encapsulateMethod.invoke(encapsulator)
+
+            val encapsulatedClass = Class.forName("javax.crypto.KEM\$Encapsulated")
+            val encapsulationMethod = encapsulatedClass.getMethod("encapsulation")
+            val ciphertext = encapsulationMethod.invoke(encapsulated) as ByteArray
+
+            val keyMethod = encapsulatedClass.getMethod("key")
+            val secretKey = keyMethod.invoke(encapsulated) as javax.crypto.SecretKey
+            val sharedSecret = secretKey.encoded
+
+            return MlKemEncapsulationResult(ciphertext, sharedSecret)
+        } catch (e: Exception) {
+            throw IOException("ML-KEM encapsulation failed", e)
+        }
+    }
+
+    override fun decapsulate(privateKey: ByteArray, ciphertext: ByteArray): ByteArray {
+        try {
+            val kf = KeyFactory.getInstance("ML-KEM")
+            val privKey: PrivateKey = kf.generatePrivate(PKCS8EncodedKeySpec(privateKey))
+
+            val kemClass = Class.forName("javax.crypto.KEM")
+            val newDecapsulator = kemClass.getMethod("newDecapsulator", PrivateKey::class.java)
+            val decapsulator = newDecapsulator.invoke(kemInstance, privKey)
+
+            val decapsulatorClass = Class.forName("javax.crypto.KEM\$Decapsulator")
+            val decapsulateMethod = decapsulatorClass.getMethod("decapsulate", ByteArray::class.java)
+            val secretKey = decapsulateMethod.invoke(decapsulator, ciphertext) as javax.crypto.SecretKey
+
+            return secretKey.encoded
+        } catch (e: Exception) {
+            throw IOException("ML-KEM decapsulation failed", e)
+        }
+    }
+
+    private fun extractRawMlKemPublicKey(x509Encoded: ByteArray): ByteArray {
+        if (x509Encoded.size < 22) throw IOException("X.509 encoded ML-KEM public key too short")
+        if (x509Encoded[0] != 0x30.toByte()) throw IOException("Invalid X.509 encoding: expected SEQUENCE tag")
+        if (x509Encoded[17] != 0x03.toByte()) throw IOException("Invalid X.509 encoding: BIT STRING not found")
+        if (x509Encoded[21] != 0x00.toByte()) throw IOException("Invalid X.509 encoding: unexpected unused bits")
+
+        val rawKey = ByteArray(MLKEM768_PUBLIC_KEY_SIZE)
+        System.arraycopy(x509Encoded, 22, rawKey, 0, MLKEM768_PUBLIC_KEY_SIZE)
+        return rawKey
+    }
+
+    private fun wrapRawMlKemPublicKey(rawKey: ByteArray): ByteArray {
+        if (rawKey.size != MLKEM768_PUBLIC_KEY_SIZE) {
+            throw IOException("Invalid raw ML-KEM public key size: ${rawKey.size}")
+        }
+        val x509 = ByteArray(X509_PREFIX.size + MLKEM768_PUBLIC_KEY_SIZE)
+        System.arraycopy(X509_PREFIX, 0, x509, 0, X509_PREFIX.size)
+        System.arraycopy(rawKey, 0, x509, X509_PREFIX.size, MLKEM768_PUBLIC_KEY_SIZE)
+        return x509
+    }
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/KexAlgorithm.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/KexAlgorithm.kt
@@ -31,6 +31,14 @@ interface KexAlgorithm {
 
     fun generateClientKeys(): ByteArray
 
+    /**
+     * Compute the shared secret K from the server's public value.
+     *
+     * The returned bytes are the wire-encoded K, ready for use in the exchange
+     * hash and key derivation. For classic DH/ECDH this is mpint encoding
+     * (uint32 length + positive integer bytes). For ML-KEM hybrid this is SSH
+     * string encoding (uint32 length + raw hash bytes).
+     */
     fun computeSharedSecret(serverPublicKey: ByteArray): ByteArray
 
     /**
@@ -38,7 +46,8 @@ interface KexAlgorithm {
      *
      * H = hash(V_C || V_S || I_C || I_S || K_S || e/Q_C || f/Q_S || K)
      *
-     * All values are encoded as SSH strings (uint32 length + data).
+     * All values except K are encoded as SSH strings (uint32 length + data).
+     * K is already wire-encoded by [computeSharedSecret] and written directly.
      */
     fun computeExchangeHash(
         clientVersion: ByteArray,
@@ -70,7 +79,7 @@ interface KexAlgorithm {
         writeString(serverHostKey)
         writeString(clientPublicKey)
         writeString(serverPublicKey)
-        writeString(sharedSecret)
+        transcript.write(sharedSecret)
 
         val md = MessageDigest.getInstance(hashAlgorithm)
         return md.digest(transcript.toByteArray())

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/KeyDerivation.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/KeyDerivation.kt
@@ -16,8 +16,6 @@
 
 package org.connectbot.sshlib.crypto
 
-import java.math.BigInteger
-import java.nio.ByteBuffer
 import java.security.MessageDigest
 
 /**
@@ -25,6 +23,9 @@ import java.security.MessageDigest
  *
  * Keys are derived from shared secret K, exchange hash H, and session ID.
  * The session ID is H from the first key exchange.
+ *
+ * @param sharedSecret Wire-encoded shared secret K (already in mpint or string format
+ *                     with uint32 length prefix, as returned by [KexAlgorithm.computeSharedSecret])
  */
 class KeyDerivation(
     private val sharedSecret: ByteArray,
@@ -64,14 +65,13 @@ class KeyDerivation(
     }
 
     /**
-     * Derive a single key according to RFC 4253.
+     * Derive a single key according to RFC 4253 section 7.2.
      *
-     * Key derivation formula:
-     * - Initial key: HASH(K || H || X || session_id)
-     * - Extended key: HASH(K || H || initial_key)
-     * - Continue extending: HASH(K || H || previous_key)
-     *
-     * Where X is a single character: 'A' to 'F' as specified in RFC 4253.
+     * K1 = HASH(K || H || X || session_id)
+     * K2 = HASH(K || H || K1)
+     * K3 = HASH(K || H || K1 || K2)
+     * ...
+     * key = K1 || K2 || K3 || ... truncated to the required length
      *
      * @param keyId Key identifier ('A' through 'F')
      * @param length Required key length in bytes
@@ -82,29 +82,24 @@ class KeyDerivation(
         var offset = 0
 
         val md = MessageDigest.getInstance(hashAlgorithm)
-        val digestLength = md.digestLength
 
-        // Convert shared secret to mpint format (SSH integer)
-        val kBytes = toMpint(sharedSecret)
-
-        // First iteration: HASH(K || H || X || session_id)
-        md.update(kBytes)
+        // K1 = HASH(K || H || X || session_id)
+        md.update(sharedSecret)
         md.update(exchangeHash)
         md.update(keyId.code.toByte())
         md.update(sessionId)
         var key = md.digest()
 
-        // Copy first chunk
         val toCopy = minOf(key.size, length - offset)
         System.arraycopy(key, 0, result, offset, toCopy)
         offset += toCopy
 
-        // Additional iterations if needed: HASH(K || H || previous_key)
+        // Kn = HASH(K || H || K1 || K2 || ... || Kn-1)
         while (offset < length) {
             md.reset()
-            md.update(kBytes)
+            md.update(sharedSecret)
             md.update(exchangeHash)
-            md.update(key)
+            md.update(result, 0, offset)
             key = md.digest()
 
             val remaining = length - offset
@@ -112,44 +107,6 @@ class KeyDerivation(
             System.arraycopy(key, 0, result, offset, copySize)
             offset += copySize
         }
-
-        return result
-    }
-
-    /**
-     * Convert byte array to SSH mpint format (RFC 4251 section 5).
-     *
-     * mpint format:
-     * - 4-byte length prefix (network byte order)
-     * - If high bit is set, prepend 0x00 to avoid being interpreted as negative
-     * - Remove leading zero bytes (except the one added above if needed)
-     */
-    private fun toMpint(value: ByteArray): ByteArray {
-        // Remove leading zeros
-        var start = 0
-        while (start < value.size - 1 && value[start] == 0.toByte()) {
-            start++
-        }
-
-        // Check if we need to add 0x00 to keep it positive
-        val needsPadding = value[start].toInt() and 0x80 != 0
-
-        val dataBytes = if (needsPadding) {
-            ByteArray(value.size - start + 1).apply {
-                this[0] = 0
-                System.arraycopy(value, start, this, 1, value.size - start)
-            }
-        } else {
-            value.copyOfRange(start, value.size)
-        }
-
-        // Add 4-byte length prefix
-        val result = ByteArray(4 + dataBytes.size)
-        result[0] = (dataBytes.size shr 24).toByte()
-        result[1] = (dataBytes.size shr 16).toByte()
-        result[2] = (dataBytes.size shr 8).toByte()
-        result[3] = dataBytes.size.toByte()
-        System.arraycopy(dataBytes, 0, result, 4, dataBytes.size)
 
         return result
     }

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/KyberKotlinMlKemProvider.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/KyberKotlinMlKemProvider.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import asia.hombre.kyber.KyberCipherText
+import asia.hombre.kyber.KyberDecapsulationKey
+import asia.hombre.kyber.KyberEncapsulationKey
+import asia.hombre.kyber.KyberKeyGenerator
+import asia.hombre.kyber.KyberParameter
+import asia.hombre.kyber.interfaces.RandomProvider
+import java.io.IOException
+import java.security.SecureRandom
+
+class KyberKotlinMlKemProvider : MlKemProvider {
+    private val randomProvider = object : RandomProvider {
+        private val secureRandom = SecureRandom()
+        override fun fillWithRandom(byteArray: ByteArray) {
+            secureRandom.nextBytes(byteArray)
+        }
+    }
+
+    override fun generateKeyPair(): MlKemKeyPair {
+        try {
+            val keyPair = KyberKeyGenerator.generate(KyberParameter.ML_KEM_768, randomProvider)
+            return MlKemKeyPair(
+                publicKey = keyPair.encapsulationKey.fullBytes,
+                privateKey = keyPair.decapsulationKey.fullBytes
+            )
+        } catch (e: Exception) {
+            throw IOException("Failed to generate Kyber key pair", e)
+        }
+    }
+
+    override fun encapsulate(publicKey: ByteArray): MlKemEncapsulationResult {
+        try {
+            val encapsKey = KyberEncapsulationKey.fromBytes(publicKey)
+            val result = encapsKey.encapsulate(randomProvider)
+            return MlKemEncapsulationResult(
+                ciphertext = result.cipherText.fullBytes,
+                sharedSecret = result.sharedSecretKey
+            )
+        } catch (e: Exception) {
+            throw IOException("Kyber encapsulation failed", e)
+        }
+    }
+
+    override fun decapsulate(privateKey: ByteArray, ciphertext: ByteArray): ByteArray {
+        try {
+            val decapsKey = KyberDecapsulationKey.fromBytes(privateKey)
+            val ct = KyberCipherText.fromBytes(ciphertext)
+            return decapsKey.decapsulate(ct)
+        } catch (e: Exception) {
+            throw IOException("Kyber decapsulation failed", e)
+        }
+    }
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/MlKemHybridKeyExchange.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/MlKemHybridKeyExchange.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import org.connectbot.sshlib.SshException
+import java.security.MessageDigest
+
+/**
+ * ML-KEM-768 hybrid key exchange (mlkem768x25519-sha256).
+ *
+ * Combines post-quantum ML-KEM-768 with classical X25519.
+ * Implements draft-ietf-sshm-mlkem-hybrid-kex.
+ *
+ * Client init message: mlkem_pubkey (1184) || x25519_pubkey (32) = 1216 bytes
+ * Server reply: mlkem_ciphertext (1088) || x25519_pubkey (32) = 1120 bytes
+ * K = SHA-256(mlkem_ss || x25519_ss)
+ */
+class MlKemHybridKeyExchange(
+    private val mlKemProvider: MlKemProvider = MlKemProviderFactory.provider,
+    private val x25519Provider: X25519Provider = X25519ProviderFactory.provider
+) : KexAlgorithm {
+    companion object {
+        private const val MLKEM768_PUBLIC_KEY_SIZE = 1184
+        private const val MLKEM768_CIPHERTEXT_SIZE = 1088
+        private const val MLKEM768_SHARED_SECRET_SIZE = 32
+        private const val X25519_KEY_SIZE = 32
+    }
+
+    override val hashAlgorithm: String = "SHA-256"
+
+    private var mlKemPrivateKey: ByteArray? = null
+    private var x25519PrivateKey: ByteArray? = null
+
+    override fun generateClientKeys(): ByteArray {
+        val mlKemKeyPair = mlKemProvider.generateKeyPair()
+        val mlKemPublicKey = mlKemKeyPair.publicKey
+        mlKemPrivateKey = mlKemKeyPair.privateKey
+
+        if (mlKemPublicKey.size != MLKEM768_PUBLIC_KEY_SIZE) {
+            throw SshException(
+                "Unexpected ML-KEM-768 public key size: ${mlKemPublicKey.size} (expected $MLKEM768_PUBLIC_KEY_SIZE)"
+            )
+        }
+
+        x25519PrivateKey = x25519Provider.generatePrivateKey()
+        val x25519PublicKey = try {
+            x25519Provider.publicFromPrivate(x25519PrivateKey!!)
+        } catch (e: Exception) {
+            throw SshException("Failed to generate X25519 public key", e)
+        }
+
+        if (x25519PublicKey.size != X25519_KEY_SIZE) {
+            throw SshException(
+                "Unexpected X25519 public key size: ${x25519PublicKey.size} (expected $X25519_KEY_SIZE)"
+            )
+        }
+
+        val init = ByteArray(mlKemPublicKey.size + x25519PublicKey.size)
+        System.arraycopy(mlKemPublicKey, 0, init, 0, mlKemPublicKey.size)
+        System.arraycopy(x25519PublicKey, 0, init, mlKemPublicKey.size, x25519PublicKey.size)
+        return init
+    }
+
+    override fun computeSharedSecret(serverPublicKey: ByteArray): ByteArray {
+        val mlKemPriv = mlKemPrivateKey
+            ?: throw SshException("Client keys not generated; call generateClientKeys() first")
+        val x25519Priv = x25519PrivateKey
+            ?: throw SshException("Client keys not generated; call generateClientKeys() first")
+
+        val expectedSize = MLKEM768_CIPHERTEXT_SIZE + X25519_KEY_SIZE
+        if (serverPublicKey.size != expectedSize) {
+            throw SshException(
+                "Invalid S_REPLY length: ${serverPublicKey.size} (expected $expectedSize)"
+            )
+        }
+
+        val mlKemCiphertext = ByteArray(MLKEM768_CIPHERTEXT_SIZE)
+        System.arraycopy(serverPublicKey, 0, mlKemCiphertext, 0, MLKEM768_CIPHERTEXT_SIZE)
+
+        val serverX25519PublicKey = ByteArray(X25519_KEY_SIZE)
+        System.arraycopy(serverPublicKey, MLKEM768_CIPHERTEXT_SIZE, serverX25519PublicKey, 0, X25519_KEY_SIZE)
+
+        try {
+            val mlKemSharedSecret = mlKemProvider.decapsulate(mlKemPriv, mlKemCiphertext)
+
+            val x25519SharedSecret = x25519Provider.computeSharedSecret(x25519Priv, serverX25519PublicKey)
+            validateNotAllZeros(x25519SharedSecret)
+
+            val combined = ByteArray(MLKEM768_SHARED_SECRET_SIZE + X25519_KEY_SIZE)
+            System.arraycopy(mlKemSharedSecret, 0, combined, 0, MLKEM768_SHARED_SECRET_SIZE)
+            System.arraycopy(x25519SharedSecret, 0, combined, MLKEM768_SHARED_SECRET_SIZE, X25519_KEY_SIZE)
+
+            return encodeSshString(MessageDigest.getInstance("SHA-256").digest(combined))
+        } catch (e: SshException) {
+            throw e
+        } catch (e: Exception) {
+            throw SshException("ML-KEM hybrid key exchange failed", e)
+        }
+    }
+
+    private fun validateNotAllZeros(secret: ByteArray) {
+        var allZero = true
+        for (b in secret) {
+            if (b.toInt() != 0) {
+                allZero = false
+                break
+            }
+        }
+        if (allZero) {
+            throw SshException("Invalid X25519 shared secret; all zeroes")
+        }
+    }
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/MlKemProvider.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/MlKemProvider.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import java.io.IOException
+
+data class MlKemKeyPair(val publicKey: ByteArray, val privateKey: ByteArray)
+data class MlKemEncapsulationResult(val ciphertext: ByteArray, val sharedSecret: ByteArray)
+
+interface MlKemProvider {
+    @Throws(IOException::class)
+    fun generateKeyPair(): MlKemKeyPair
+
+    @Throws(IOException::class)
+    fun encapsulate(publicKey: ByteArray): MlKemEncapsulationResult
+
+    @Throws(IOException::class)
+    fun decapsulate(privateKey: ByteArray, ciphertext: ByteArray): ByteArray
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/MlKemProviderFactory.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/MlKemProviderFactory.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import org.slf4j.LoggerFactory
+
+object MlKemProviderFactory {
+    private val logger = LoggerFactory.getLogger(MlKemProviderFactory::class.java)
+
+    val provider: MlKemProvider by lazy {
+        try {
+            val p = JavaMlKemProvider()
+            logger.debug("Using Java 23+ native ML-KEM implementation")
+            p
+        } catch (e: Exception) {
+            logger.debug("Java KEM API not available, falling back to Kyber Kotlin")
+            KyberKotlinMlKemProvider()
+        }
+    }
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/PacketAead.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/PacketAead.kt
@@ -28,6 +28,8 @@ data class AeadResult(val ciphertext: ByteArray, val tag: ByteArray)
 interface PacketAead {
     val tagLength: Int
 
+    val encryptsLength: Boolean get() = false
+
     /**
      * Encrypt plaintext with the packet length as AAD.
      *
@@ -47,4 +49,10 @@ interface PacketAead {
      * @throws org.connectbot.sshlib.transport.TransportException if authentication fails
      */
     fun decrypt(packetLength: ByteArray, ciphertext: ByteArray, tag: ByteArray): ByteArray
+
+    fun encryptLength(sequenceNumber: Long, plainLength: ByteArray): ByteArray =
+        throw UnsupportedOperationException("This cipher does not encrypt the length field")
+
+    fun decryptLength(sequenceNumber: Long, encryptedLength: ByteArray): ByteArray =
+        throw UnsupportedOperationException("This cipher does not encrypt the length field")
 }

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/PlatformX25519Provider.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/PlatformX25519Provider.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import java.security.InvalidKeyException
+import java.security.KeyFactory
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.X509EncodedKeySpec
+import java.security.spec.XECPrivateKeySpec
+import javax.crypto.KeyAgreement
+
+class PlatformX25519Provider : X25519Provider {
+    companion object {
+        private const val ALGORITHM = "X25519"
+
+        private val PKCS8_PREFIX = byteArrayOf(
+            0x30, 0x2e,                         // SEQUENCE (46 bytes)
+            0x02, 0x01, 0x00,                   // INTEGER 0 (version)
+            0x30, 0x05,                         // SEQUENCE (5 bytes)
+            0x06, 0x03, 0x2b, 0x65, 0x6e,      // OID 1.3.101.110 (X25519)
+            0x04, 0x22,                         // OCTET STRING (34 bytes)
+            0x04, 0x20                          // OCTET STRING (32 bytes)
+        )
+
+        private val X509_PREFIX = byteArrayOf(
+            0x30, 0x2a,                         // SEQUENCE (42 bytes)
+            0x30, 0x05,                         // SEQUENCE (5 bytes)
+            0x06, 0x03, 0x2b, 0x65, 0x6e,      // OID 1.3.101.110 (X25519)
+            0x03, 0x21, 0x00                    // BIT STRING (33 bytes, 0 unused bits)
+        )
+
+        private val BASE_POINT = ByteArray(X25519Provider.KEY_SIZE).apply { this[0] = 9 }
+    }
+
+    private val keyPairGenerator = KeyPairGenerator.getInstance(ALGORITHM)
+    private val keyFactory = KeyFactory.getInstance(ALGORITHM)
+
+    override fun generatePrivateKey(): ByteArray {
+        val keyPair = keyPairGenerator.generateKeyPair()
+        return extractPrivateKeyBytes(keyPair.private)
+    }
+
+    override fun publicFromPrivate(privateKey: ByteArray): ByteArray {
+        val privKey = createPrivateKey(privateKey)
+        val ka = KeyAgreement.getInstance(ALGORITHM)
+        ka.init(privKey)
+        ka.doPhase(createPublicKey(BASE_POINT), true)
+        return ka.generateSecret()
+    }
+
+    override fun computeSharedSecret(privateKey: ByteArray, publicKey: ByteArray): ByteArray {
+        val privKey = createPrivateKey(privateKey)
+        val pubKey = createPublicKey(publicKey)
+        val ka = KeyAgreement.getInstance(ALGORITHM)
+        ka.init(privKey)
+        ka.doPhase(pubKey, true)
+        return ka.generateSecret()
+    }
+
+    private fun createPrivateKey(keyBytes: ByteArray): PrivateKey {
+        val pkcs8 = ByteArray(PKCS8_PREFIX.size + X25519Provider.KEY_SIZE)
+        System.arraycopy(PKCS8_PREFIX, 0, pkcs8, 0, PKCS8_PREFIX.size)
+        System.arraycopy(keyBytes, 0, pkcs8, PKCS8_PREFIX.size, X25519Provider.KEY_SIZE)
+        return keyFactory.generatePrivate(PKCS8EncodedKeySpec(pkcs8))
+    }
+
+    private fun createPublicKey(keyBytes: ByteArray): PublicKey {
+        val x509 = ByteArray(X509_PREFIX.size + X25519Provider.KEY_SIZE)
+        System.arraycopy(X509_PREFIX, 0, x509, 0, X509_PREFIX.size)
+        System.arraycopy(keyBytes, 0, x509, X509_PREFIX.size, X25519Provider.KEY_SIZE)
+        return keyFactory.generatePublic(X509EncodedKeySpec(x509))
+    }
+
+    private fun extractPrivateKeyBytes(privateKey: PrivateKey): ByteArray {
+        val spec = keyFactory.getKeySpec(privateKey, XECPrivateKeySpec::class.java)
+        val scalar = spec.scalar
+        if (scalar.size == X25519Provider.KEY_SIZE) return scalar
+        val padded = ByteArray(X25519Provider.KEY_SIZE)
+        System.arraycopy(scalar, 0, padded, X25519Provider.KEY_SIZE - scalar.size, scalar.size)
+        return padded
+    }
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/Poly1305.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/Poly1305.kt
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+/**
+ * Poly1305 one-time authenticator per RFC 8439.
+ *
+ * Uses a 5x27-bit limb accumulator representation for the modular arithmetic.
+ */
+class Poly1305 {
+    companion object {
+        private const val BLOCK_SIZE = 16
+    }
+
+    private var h0 = 0; private var h1 = 0; private var h2 = 0; private var h3 = 0; private var h4 = 0
+    private var r0 = 0; private var r1 = 0; private var r2 = 0; private var r3 = 0; private var r4 = 0
+    private var s0 = 0; private var s1 = 0; private var s2 = 0; private var s3 = 0
+
+    private var buffer = ByteArray(BLOCK_SIZE)
+    private var bufferPos = 0
+    private var finished = false
+
+    fun init(key: ByteArray) {
+        require(key.size == 32) { "Poly1305 key must be 32 bytes" }
+
+        val t0 = readIntLE(key, 0)
+        val t1 = readIntLE(key, 4)
+        val t2 = readIntLE(key, 8)
+        val t3 = readIntLE(key, 12)
+
+        r0 = t0 and 0x3ffffff
+        r1 = ((t0 ushr 26) or (t1 shl 6)) and 0x3ffff03
+        r2 = ((t1 ushr 20) or (t2 shl 12)) and 0x3ffc0ff
+        r3 = ((t2 ushr 14) or (t3 shl 18)) and 0x3f03fff
+        r4 = (t3 ushr 8) and 0x00fffff
+
+        s0 = readIntLE(key, 16)
+        s1 = readIntLE(key, 20)
+        s2 = readIntLE(key, 24)
+        s3 = readIntLE(key, 28)
+
+        h0 = 0; h1 = 0; h2 = 0; h3 = 0; h4 = 0
+        buffer = ByteArray(BLOCK_SIZE)
+        bufferPos = 0
+        finished = false
+    }
+
+    fun update(data: ByteArray, offset: Int, length: Int) {
+        check(!finished) { "Poly1305 already finished" }
+
+        var remaining = length
+        var pos = offset
+
+        if (bufferPos > 0) {
+            val toCopy = minOf(BLOCK_SIZE - bufferPos, remaining)
+            System.arraycopy(data, pos, buffer, bufferPos, toCopy)
+            bufferPos += toCopy
+            pos += toCopy
+            remaining -= toCopy
+
+            if (bufferPos == BLOCK_SIZE) {
+                processBlock(buffer, 0, false)
+                bufferPos = 0
+            }
+        }
+
+        while (remaining >= BLOCK_SIZE) {
+            processBlock(data, pos, false)
+            pos += BLOCK_SIZE
+            remaining -= BLOCK_SIZE
+        }
+
+        if (remaining > 0) {
+            System.arraycopy(data, pos, buffer, 0, remaining)
+            bufferPos = remaining
+        }
+    }
+
+    fun finish(tag: ByteArray, offset: Int) {
+        check(!finished) { "Poly1305 already finished" }
+
+        if (bufferPos > 0) {
+            buffer[bufferPos] = 1
+            for (i in bufferPos + 1 until BLOCK_SIZE) {
+                buffer[i] = 0
+            }
+            bufferPos++
+            processBlock(buffer, 0, true)
+        }
+
+        // Fully reduce h mod (2^130 - 5)
+        var c: Long
+
+        c = Integer.toUnsignedLong(h0) + 5
+        val g0 = c.toInt() and 0x03ffffff
+        c = c ushr 26
+        c += h1
+        val g1 = c.toInt() and 0x03ffffff
+        c = c ushr 26
+        c += h2
+        val g2 = c.toInt() and 0x03ffffff
+        c = c ushr 26
+        c += h3
+        val g3 = c.toInt() and 0x03ffffff
+        c = c ushr 26
+        c += h4
+        var g4 = c.toInt() and 0x03ffffff
+        g4 -= (1 shl 26)
+
+        var mask = -(c ushr 26).toInt()
+        val nmask = mask.inv()
+        h0 = (h0 and nmask) or (g0 and mask)
+        h1 = (h1 and nmask) or (g1 and mask)
+        h2 = (h2 and nmask) or (g2 and mask)
+        h3 = (h3 and nmask) or (g3 and mask)
+        h4 = (h4 and nmask) or (g4 and mask)
+
+        // h = h mod 2^128
+        h0 = h0 or (h1 shl 26)
+        h1 = (h1 ushr 6) or (h2 shl 20)
+        h2 = (h2 ushr 12) or (h3 shl 14)
+        h3 = (h3 ushr 18) or (h4 shl 8)
+
+        // h = (h + s) mod 2^128
+        c = Integer.toUnsignedLong(h0) + Integer.toUnsignedLong(s0)
+        h0 = c.toInt()
+        c = Integer.toUnsignedLong(h1) + Integer.toUnsignedLong(s1) + (c ushr 32)
+        h1 = c.toInt()
+        c = Integer.toUnsignedLong(h2) + Integer.toUnsignedLong(s2) + (c ushr 32)
+        h2 = c.toInt()
+        c = Integer.toUnsignedLong(h3) + Integer.toUnsignedLong(s3) + (c ushr 32)
+        h3 = c.toInt()
+
+        writeIntLE(h0, tag, offset)
+        writeIntLE(h1, tag, offset + 4)
+        writeIntLE(h2, tag, offset + 8)
+        writeIntLE(h3, tag, offset + 12)
+
+        finished = true
+        reset()
+    }
+
+    fun reset() {
+        r0 = 0; r1 = 0; r2 = 0; r3 = 0; r4 = 0
+        s0 = 0; s1 = 0; s2 = 0; s3 = 0
+        h0 = 0; h1 = 0; h2 = 0; h3 = 0; h4 = 0
+        buffer.fill(0)
+        bufferPos = 0
+    }
+
+    private fun processBlock(block: ByteArray, offset: Int, isFinal: Boolean) {
+        val t0 = readIntLE(block, offset)
+        val t1 = readIntLE(block, offset + 4)
+        val t2 = readIntLE(block, offset + 8)
+        val t3 = readIntLE(block, offset + 12)
+
+        val hibit = if (isFinal && bufferPos < BLOCK_SIZE) 0 else (1 shl 24)
+
+        val d0 = Integer.toUnsignedLong(h0) + (t0.toLong() and 0x03ffffffL)
+        val d1 = Integer.toUnsignedLong(h1) + ((((t0 ushr 26) or (t1 shl 6)).toLong()) and 0x03ffffffL)
+        val d2 = Integer.toUnsignedLong(h2) + ((((t1 ushr 20) or (t2 shl 12)).toLong()) and 0x03ffffffL)
+        val d3 = Integer.toUnsignedLong(h3) + ((((t2 ushr 14) or (t3 shl 18)).toLong()) and 0x03ffffffL)
+        val d4 = Integer.toUnsignedLong(h4) + (((t3 ushr 8) or hibit).toLong() and 0xffffffffL)
+
+        val r0L = r0.toLong() and 0xffffffffL
+        val r1L = r1.toLong() and 0xffffffffL
+        val r2L = r2.toLong() and 0xffffffffL
+        val r3L = r3.toLong() and 0xffffffffL
+        val r4L = r4.toLong() and 0xffffffffL
+
+        var c: Long = 0
+        c = d0 * r0L
+        c += d1 * (r4L * 5)
+        c += d2 * (r3L * 5)
+        c += d3 * (r2L * 5)
+        c += d4 * (r1L * 5)
+        h0 = c.toInt() and 0x03ffffff
+        c = c ushr 26
+
+        c += d0 * r1L
+        c += d1 * r0L
+        c += d2 * (r4L * 5)
+        c += d3 * (r3L * 5)
+        c += d4 * (r2L * 5)
+        h1 = c.toInt() and 0x03ffffff
+        c = c ushr 26
+
+        c += d0 * r2L
+        c += d1 * r1L
+        c += d2 * r0L
+        c += d3 * (r4L * 5)
+        c += d4 * (r3L * 5)
+        h2 = c.toInt() and 0x03ffffff
+        c = c ushr 26
+
+        c += d0 * r3L
+        c += d1 * r2L
+        c += d2 * r1L
+        c += d3 * r0L
+        c += d4 * (r4L * 5)
+        h3 = c.toInt() and 0x03ffffff
+        c = c ushr 26
+
+        c += d0 * r4L
+        c += d1 * r3L
+        c += d2 * r2L
+        c += d3 * r1L
+        c += d4 * r0L
+        h4 = c.toInt() and 0x03ffffff
+        c = c ushr 26
+
+        h0 += (c * 5).toInt()
+        h1 += h0 ushr 26
+        h0 = h0 and 0x03ffffff
+    }
+
+    private fun readIntLE(buf: ByteArray, offset: Int): Int =
+        (buf[offset].toInt() and 0xff) or
+            ((buf[offset + 1].toInt() and 0xff) shl 8) or
+            ((buf[offset + 2].toInt() and 0xff) shl 16) or
+            ((buf[offset + 3].toInt() and 0xff) shl 24)
+
+    private fun writeIntLE(value: Int, buf: ByteArray, offset: Int) {
+        buf[offset] = value.toByte()
+        buf[offset + 1] = (value ushr 8).toByte()
+        buf[offset + 2] = (value ushr 16).toByte()
+        buf[offset + 3] = (value ushr 24).toByte()
+    }
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/SshEncoding.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/SshEncoding.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+/**
+ * Encode a BigInteger-style byte array as an SSH mpint (RFC 4251 section 5).
+ *
+ * Returns uint32(length) || body, where body has leading zeros stripped and
+ * a 0x00 prepended if the high bit is set (to keep the value positive).
+ */
+fun encodeMpint(value: ByteArray): ByteArray {
+    var start = 0
+    while (start < value.size - 1 && value[start] == 0.toByte()) {
+        start++
+    }
+
+    val needsPadding = value[start].toInt() and 0x80 != 0
+    val bodyLen = value.size - start + if (needsPadding) 1 else 0
+
+    val result = ByteArray(4 + bodyLen)
+    result[0] = (bodyLen shr 24).toByte()
+    result[1] = (bodyLen shr 16).toByte()
+    result[2] = (bodyLen shr 8).toByte()
+    result[3] = bodyLen.toByte()
+
+    if (needsPadding) {
+        result[4] = 0
+        System.arraycopy(value, start, result, 5, value.size - start)
+    } else {
+        System.arraycopy(value, start, result, 4, value.size - start)
+    }
+    return result
+}
+
+/**
+ * Encode a raw byte array as an SSH string (RFC 4251 section 5).
+ *
+ * Returns uint32(length) || data.
+ */
+fun encodeSshString(value: ByteArray): ByteArray {
+    val result = ByteArray(4 + value.size)
+    result[0] = (value.size shr 24).toByte()
+    result[1] = (value.size shr 16).toByte()
+    result[2] = (value.size shr 8).toByte()
+    result[3] = value.size.toByte()
+    System.arraycopy(value, 0, result, 4, value.size)
+    return result
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/TinkX25519Provider.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/TinkX25519Provider.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import com.google.crypto.tink.subtle.X25519
+
+class TinkX25519Provider : X25519Provider {
+    override fun generatePrivateKey(): ByteArray = X25519.generatePrivateKey()
+
+    override fun publicFromPrivate(privateKey: ByteArray): ByteArray =
+        X25519.publicFromPrivate(privateKey)
+
+    override fun computeSharedSecret(privateKey: ByteArray, publicKey: ByteArray): ByteArray =
+        X25519.computeSharedSecret(privateKey, publicKey)
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/X25519Provider.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/X25519Provider.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import java.security.InvalidKeyException
+
+interface X25519Provider {
+    companion object {
+        const val KEY_SIZE = 32
+    }
+
+    fun generatePrivateKey(): ByteArray
+
+    @Throws(InvalidKeyException::class)
+    fun publicFromPrivate(privateKey: ByteArray): ByteArray
+
+    @Throws(InvalidKeyException::class)
+    fun computeSharedSecret(privateKey: ByteArray, publicKey: ByteArray): ByteArray
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/X25519ProviderFactory.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/X25519ProviderFactory.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import org.slf4j.LoggerFactory
+import java.security.KeyPairGenerator
+
+object X25519ProviderFactory {
+    private val logger = LoggerFactory.getLogger(X25519ProviderFactory::class.java)
+
+    val provider: X25519Provider by lazy {
+        if (isPlatformNativeAvailable()) {
+            try {
+                val p = PlatformX25519Provider()
+                logger.debug("Using platform-native X25519 implementation")
+                p
+            } catch (e: Exception) {
+                logger.debug("Platform X25519 class loading failed, falling back to Tink")
+                createTinkProvider()
+            }
+        } else {
+            logger.debug("Using Tink X25519 implementation")
+            createTinkProvider()
+        }
+    }
+
+    private fun isPlatformNativeAvailable(): Boolean = try {
+        KeyPairGenerator.getInstance("X25519")
+        true
+    } catch (_: Exception) {
+        false
+    }
+
+    private fun createTinkProvider(): X25519Provider {
+        return TinkX25519Provider()
+    }
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/transport/PacketIO.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/transport/PacketIO.kt
@@ -275,9 +275,24 @@ class PacketIO(private val transport: Transport) {
      * Wire format: packet_length (4B, cleartext) || ciphertext || auth_tag (16B)
      * AAD: the 4-byte packet_length
      * Plaintext: padding_length || payload || padding
+     *
+     * For ciphers that encrypt the length (e.g., ChaCha20-Poly1305):
+     * Wire format: encrypted_length (4B) || ciphertext || auth_tag (16B)
+     * The encrypted length bytes are passed as AAD to encrypt/decrypt.
      */
     private suspend fun readAeadPacket(aead: PacketAead): UnencryptedPacket.UnencryptedPayload {
-        val lengthBytes = transport.read(4)
+        val wireLength = transport.read(4)
+
+        val lengthBytes: ByteArray
+        val aadBytes: ByteArray
+        if (aead.encryptsLength) {
+            aadBytes = wireLength.clone()
+            lengthBytes = aead.decryptLength(receiveSequenceNumber, wireLength)
+        } else {
+            lengthBytes = wireLength
+            aadBytes = wireLength
+        }
+
         val packetLength = ByteBuffer.wrap(lengthBytes).int
 
         if (packetLength < MIN_PACKET_LENGTH || packetLength > MAX_PACKET_LENGTH) {
@@ -287,7 +302,7 @@ class PacketIO(private val transport: Transport) {
         val ciphertext = transport.read(packetLength)
         val tag = transport.read(aead.tagLength)
 
-        val plaintext = aead.decrypt(lengthBytes, ciphertext, tag)
+        val plaintext = aead.decrypt(aadBytes, ciphertext, tag)
 
         val fullPacket = lengthBytes + plaintext
         val stream = ByteBufferKaitaiStream(fullPacket)
@@ -446,6 +461,10 @@ class PacketIO(private val transport: Transport) {
      * Wire format: packet_length (4B, cleartext) || ciphertext || auth_tag (16B)
      * Plaintext: padding_length || message_type || payload || padding
      * Padding must align the plaintext to a 16-byte boundary.
+     *
+     * For ciphers that encrypt the length (e.g., ChaCha20-Poly1305):
+     * Wire format: encrypted_length (4B) || ciphertext || auth_tag (16B)
+     * The encrypted length bytes are passed as AAD to encrypt.
      */
     private suspend fun writeAeadPacket(
         messageType: Int,
@@ -453,7 +472,7 @@ class PacketIO(private val transport: Transport) {
         aead: PacketAead
     ) {
         val payloadLength = 1 + payload.size // message type + payload
-        val blockSize = 16 // AES block size for GCM padding alignment
+        val blockSize = if (aead.encryptsLength) 8 else 16
 
         val paddingLength = calculateAeadPaddingLength(payloadLength, blockSize)
         val packetLength = 1 + payloadLength + paddingLength
@@ -467,9 +486,19 @@ class PacketIO(private val transport: Transport) {
         val plaintext = plaintextBuffer.toByteArray()
         val lengthBytes = ByteBuffer.allocate(4).putInt(packetLength).array()
 
-        val result = aead.encrypt(lengthBytes, plaintext)
+        val wireLength: ByteArray
+        val aadBytes: ByteArray
+        if (aead.encryptsLength) {
+            wireLength = aead.encryptLength(sendSequenceNumber, lengthBytes)
+            aadBytes = wireLength
+        } else {
+            wireLength = lengthBytes
+            aadBytes = lengthBytes
+        }
 
-        transport.write(lengthBytes + result.ciphertext + result.tag)
+        val result = aead.encrypt(aadBytes, plaintext)
+
+        transport.write(wireLength + result.ciphertext + result.tag)
         sendSequenceNumber++
     }
 

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/ChaCha20Poly1305CipherTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/ChaCha20Poly1305CipherTest.kt
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import org.connectbot.sshlib.transport.TransportException
+import org.junit.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ChaCha20Poly1305CipherTest {
+
+    // RFC 8439 Section 2.5.2 Poly1305 test vector
+    @Test
+    fun `Poly1305 RFC 8439 test vector`() {
+        val key = hexToBytes(
+            "85d6be7857556d337f4452fe42d506a8" +
+            "0103808afb0db2fd4abff6af4149f51b"
+        )
+        val message = "Cryptographic Forum Research Group".toByteArray(Charsets.US_ASCII)
+        val expectedTag = hexToBytes("a8061dc1305136c6c22b8baf0c0127a9")
+
+        val poly = Poly1305()
+        poly.init(key)
+        poly.update(message, 0, message.size)
+        val tag = ByteArray(16)
+        poly.finish(tag, 0)
+
+        assertContentEquals(expectedTag, tag)
+    }
+
+    @Test
+    fun `Poly1305 with multi-block input`() {
+        val key = hexToBytes(
+            "85d6be7857556d337f4452fe42d506a8" +
+            "0103808afb0db2fd4abff6af4149f51b"
+        )
+        val message = "Cryptographic Forum Research Group".toByteArray(Charsets.US_ASCII)
+
+        val poly1 = Poly1305()
+        poly1.init(key)
+        poly1.update(message, 0, message.size)
+        val tag1 = ByteArray(16)
+        poly1.finish(tag1, 0)
+
+        // Feed byte-by-byte to test buffering
+        val poly2 = Poly1305()
+        poly2.init(key)
+        for (b in message) {
+            poly2.update(byteArrayOf(b), 0, 1)
+        }
+        val tag2 = ByteArray(16)
+        poly2.finish(tag2, 0)
+
+        assertContentEquals(tag1, tag2)
+    }
+
+    @Test
+    fun `length encryption roundtrip`() {
+        val key = ByteArray(64).apply {
+            for (i in indices) this[i] = i.toByte()
+        }
+        val cipher = ChaCha20Poly1305Cipher(key)
+
+        val plainLength = byteArrayOf(0x00, 0x00, 0x00, 0x14) // 20 bytes
+        val seqNum = 42L
+
+        val encrypted = cipher.encryptLength(seqNum, plainLength)
+        val decrypted = cipher.decryptLength(seqNum, encrypted)
+
+        assertContentEquals(plainLength, decrypted)
+    }
+
+    @Test
+    fun `encrypt and decrypt roundtrip`() {
+        val key = ByteArray(64).apply {
+            for (i in indices) this[i] = i.toByte()
+        }
+        val encCipher = ChaCha20Poly1305Cipher(key)
+        val decCipher = ChaCha20Poly1305Cipher(key)
+
+        val seqNum = 1L
+        val plainLength = byteArrayOf(0x00, 0x00, 0x00, 0x20)
+        val plaintext = ByteArray(32) { (it * 3).toByte() }
+
+        val encryptedLength = encCipher.encryptLength(seqNum, plainLength)
+        val result = encCipher.encrypt(encryptedLength, plaintext)
+
+        decCipher.decryptLength(seqNum, encryptedLength)
+        val decrypted = decCipher.decrypt(encryptedLength, result.ciphertext, result.tag)
+
+        assertContentEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun `tag verification failure on modified ciphertext`() {
+        val key = ByteArray(64).apply {
+            for (i in indices) this[i] = i.toByte()
+        }
+        val encCipher = ChaCha20Poly1305Cipher(key)
+        val decCipher = ChaCha20Poly1305Cipher(key)
+
+        val seqNum = 5L
+        val plainLength = byteArrayOf(0x00, 0x00, 0x00, 0x10)
+        val plaintext = ByteArray(16) { it.toByte() }
+
+        val encryptedLength = encCipher.encryptLength(seqNum, plainLength)
+        val result = encCipher.encrypt(encryptedLength, plaintext)
+
+        // Tamper with ciphertext
+        val tampered = result.ciphertext.clone()
+        tampered[0] = (tampered[0].toInt() xor 0xff).toByte()
+
+        decCipher.decryptLength(seqNum, encryptedLength)
+        assertFailsWith<TransportException> {
+            decCipher.decrypt(encryptedLength, tampered, result.tag)
+        }
+    }
+
+    @Test
+    fun `tag verification failure on modified tag`() {
+        val key = ByteArray(64).apply {
+            for (i in indices) this[i] = i.toByte()
+        }
+        val encCipher = ChaCha20Poly1305Cipher(key)
+        val decCipher = ChaCha20Poly1305Cipher(key)
+
+        val seqNum = 7L
+        val plainLength = byteArrayOf(0x00, 0x00, 0x00, 0x10)
+        val plaintext = ByteArray(16) { it.toByte() }
+
+        val encryptedLength = encCipher.encryptLength(seqNum, plainLength)
+        val result = encCipher.encrypt(encryptedLength, plaintext)
+
+        // Tamper with tag
+        val tamperedTag = result.tag.clone()
+        tamperedTag[0] = (tamperedTag[0].toInt() xor 0xff).toByte()
+
+        decCipher.decryptLength(seqNum, encryptedLength)
+        assertFailsWith<TransportException> {
+            decCipher.decrypt(encryptedLength, result.ciphertext, tamperedTag)
+        }
+    }
+
+    @Test
+    fun `encryptsLength returns true`() {
+        val key = ByteArray(64)
+        val cipher = ChaCha20Poly1305Cipher(key)
+        assertEquals(true, cipher.encryptsLength)
+    }
+
+    @Test
+    fun `tagLength returns 16`() {
+        val key = ByteArray(64)
+        val cipher = ChaCha20Poly1305Cipher(key)
+        assertEquals(16, cipher.tagLength)
+    }
+
+    @Test
+    fun `rejects invalid key size`() {
+        assertFailsWith<IllegalArgumentException> {
+            ChaCha20Poly1305Cipher(ByteArray(32))
+        }
+    }
+
+    @Test
+    fun `multiple packets with incrementing sequence numbers`() {
+        val key = ByteArray(64).apply {
+            for (i in indices) this[i] = (i * 7).toByte()
+        }
+        val encCipher = ChaCha20Poly1305Cipher(key)
+        val decCipher = ChaCha20Poly1305Cipher(key)
+
+        for (seq in 0L..5L) {
+            val plainLength = byteArrayOf(0x00, 0x00, 0x00, 0x08)
+            val plaintext = ByteArray(8) { (it + seq.toInt()).toByte() }
+
+            val encLen = encCipher.encryptLength(seq, plainLength)
+            val result = encCipher.encrypt(encLen, plaintext)
+
+            decCipher.decryptLength(seq, encLen)
+            val decrypted = decCipher.decrypt(encLen, result.ciphertext, result.tag)
+
+            assertContentEquals(plaintext, decrypted, "Failed at seq=$seq")
+        }
+    }
+
+    private fun hexToBytes(hex: String): ByteArray =
+        hex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+}

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/Curve25519KeyExchangeTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/Curve25519KeyExchangeTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import org.connectbot.sshlib.SshException
+import org.junit.Test
+import java.math.BigInteger
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class Curve25519KeyExchangeTest {
+    // RFC 7748 Section 6.1 test vectors
+    private val alicePrivate = hexToBytes(
+        "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a"
+    )
+    private val alicePublic = hexToBytes(
+        "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a"
+    )
+    private val bobPrivate = hexToBytes(
+        "5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb"
+    )
+    private val bobPublic = hexToBytes(
+        "de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f"
+    )
+    private val expectedSharedSecret = hexToBytes(
+        "4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742"
+    )
+
+    @Test
+    fun `public key derivation from RFC 7748 test vector`() {
+        val provider = X25519ProviderFactory.provider
+        val publicKey = provider.publicFromPrivate(alicePrivate)
+        assertContentEquals(alicePublic, publicKey)
+    }
+
+    @Test
+    fun `shared secret computation with RFC 7748 test vectors`() {
+        val provider = X25519ProviderFactory.provider
+        val secret = provider.computeSharedSecret(alicePrivate, bobPublic)
+        assertContentEquals(expectedSharedSecret, secret)
+    }
+
+    @Test
+    fun `generateClientKeys returns 32-byte public key`() {
+        val kex = Curve25519KeyExchange()
+        val publicKey = kex.generateClientKeys()
+        assertEquals(32, publicKey.size)
+    }
+
+    @Test
+    fun `computeSharedSecret returns wire-encoded mpint`() {
+        val aliceKex = Curve25519KeyExchange(X25519ProviderFactory.provider, alicePrivate)
+        aliceKex.generateClientKeys()
+        val encoded = aliceKex.computeSharedSecret(bobPublic)
+        val expectedMpint = encodeMpint(BigInteger(1, expectedSharedSecret).toByteArray())
+        assertContentEquals(expectedMpint, encoded)
+    }
+
+    @Test
+    fun `shared secret roundtrip between two parties`() {
+        val aliceKex = Curve25519KeyExchange()
+        val bobKex = Curve25519KeyExchange()
+
+        val alicePub = aliceKex.generateClientKeys()
+        val bobPub = bobKex.generateClientKeys()
+
+        val aliceSecret = aliceKex.computeSharedSecret(bobPub)
+        val bobSecret = bobKex.computeSharedSecret(alicePub)
+
+        assertContentEquals(aliceSecret, bobSecret)
+    }
+
+    @Test
+    fun `rejects server key with wrong size`() {
+        val kex = Curve25519KeyExchange()
+        kex.generateClientKeys()
+        assertFailsWith<SshException> {
+            kex.computeSharedSecret(ByteArray(16))
+        }
+    }
+
+    @Test
+    fun `rejects all-zero shared secret`() {
+        val allZeroPublic = ByteArray(32)
+        val kex = Curve25519KeyExchange()
+        kex.generateClientKeys()
+        assertFailsWith<SshException> {
+            kex.computeSharedSecret(allZeroPublic)
+        }
+    }
+
+    @Test
+    fun `hash algorithm is SHA-256`() {
+        val kex = Curve25519KeyExchange()
+        assertEquals("SHA-256", kex.hashAlgorithm)
+    }
+
+    private fun hexToBytes(hex: String): ByteArray {
+        return hex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+    }
+}

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/DiffieHellmanGroupExchangeTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/DiffieHellmanGroupExchangeTest.kt
@@ -70,7 +70,7 @@ class DiffieHellmanGroupExchangeTest {
         serverAgreement.doPhase(clientPubKey, true)
         val serverRawSecret = serverAgreement.generateSecret()
 
-        val serverSecret = BigInteger(1, serverRawSecret).toByteArray()
+        val serverSecret = encodeMpint(BigInteger(1, serverRawSecret).toByteArray())
 
         assertContentEquals(serverSecret, clientSecret)
     }

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/DiffieHellmanTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/DiffieHellmanTest.kt
@@ -102,7 +102,7 @@ class DiffieHellmanTest {
         val serverRawSecret = serverAgreement.generateSecret()
 
         val serverBigInt = BigInteger(1, serverRawSecret)
-        val serverSecret = serverBigInt.toByteArray()
+        val serverSecret = encodeMpint(serverBigInt.toByteArray())
 
         assertContentEquals(serverSecret, clientSecret)
     }

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/EcdhKeyExchangeTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/EcdhKeyExchangeTest.kt
@@ -18,6 +18,7 @@ package org.connectbot.sshlib.crypto
 
 import org.connectbot.sshlib.SshException
 import org.junit.Test
+import java.math.BigInteger
 import java.security.KeyPairGenerator
 import java.security.interfaces.ECPublicKey
 import java.security.spec.ECGenParameterSpec
@@ -100,9 +101,8 @@ class EcdhKeyExchangeTest {
         serverAgreement.doPhase(clientPubKey, true)
         val serverRawSecret = serverAgreement.generateSecret()
 
-        // Convert server raw secret to positive BigInteger bytes (same as EcdhKeyExchange)
-        val serverBigInt = java.math.BigInteger(1, serverRawSecret)
-        val serverSecret = serverBigInt.toByteArray()
+        val serverBigInt = BigInteger(1, serverRawSecret)
+        val serverSecret = encodeMpint(serverBigInt.toByteArray())
 
         assertContentEquals(serverSecret, clientSecret)
     }

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/MlKemHybridKeyExchangeTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/MlKemHybridKeyExchangeTest.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import org.connectbot.sshlib.SshException
+import org.junit.Test
+import java.security.MessageDigest
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class MlKemHybridKeyExchangeTest {
+
+    private val fakeMlKemPublicKey = ByteArray(1184) { (it % 256).toByte() }
+    private val fakeMlKemPrivateKey = ByteArray(2400) { ((it * 3) % 256).toByte() }
+    private val fakeMlKemCiphertext = ByteArray(1088) { ((it * 7) % 256).toByte() }
+    private val fakeMlKemSharedSecret = ByteArray(32) { ((it + 10) % 256).toByte() }
+
+    private val fakeX25519Private = ByteArray(32) { ((it + 1) % 256).toByte() }
+    private val fakeX25519Public = ByteArray(32) { ((it + 50) % 256).toByte() }
+    private val fakeX25519ServerPublic = ByteArray(32) { ((it + 100) % 256).toByte() }
+    private val fakeX25519SharedSecret = ByteArray(32) { ((it + 200) % 256).toByte() }
+
+    private val mockMlKemProvider = object : MlKemProvider {
+        override fun generateKeyPair(): MlKemKeyPair =
+            MlKemKeyPair(fakeMlKemPublicKey.clone(), fakeMlKemPrivateKey.clone())
+
+        override fun encapsulate(publicKey: ByteArray): MlKemEncapsulationResult =
+            MlKemEncapsulationResult(fakeMlKemCiphertext.clone(), fakeMlKemSharedSecret.clone())
+
+        override fun decapsulate(privateKey: ByteArray, ciphertext: ByteArray): ByteArray =
+            fakeMlKemSharedSecret.clone()
+    }
+
+    private val mockX25519Provider = object : X25519Provider {
+        override fun generatePrivateKey(): ByteArray = fakeX25519Private.clone()
+        override fun publicFromPrivate(privateKey: ByteArray): ByteArray = fakeX25519Public.clone()
+        override fun computeSharedSecret(privateKey: ByteArray, publicKey: ByteArray): ByteArray =
+            fakeX25519SharedSecret.clone()
+    }
+
+    @Test
+    fun `client init message is 1216 bytes`() {
+        val kex = MlKemHybridKeyExchange(mockMlKemProvider, mockX25519Provider)
+        val clientInit = kex.generateClientKeys()
+        assertEquals(1216, clientInit.size)
+    }
+
+    @Test
+    fun `client init message format is mlkem_pubkey then x25519_pubkey`() {
+        val kex = MlKemHybridKeyExchange(mockMlKemProvider, mockX25519Provider)
+        val clientInit = kex.generateClientKeys()
+
+        val mlKemPart = clientInit.copyOfRange(0, 1184)
+        val x25519Part = clientInit.copyOfRange(1184, 1216)
+
+        assertContentEquals(fakeMlKemPublicKey, mlKemPart)
+        assertContentEquals(fakeX25519Public, x25519Part)
+    }
+
+    @Test
+    fun `server reply parsing - valid 1120 byte reply`() {
+        val kex = MlKemHybridKeyExchange(mockMlKemProvider, mockX25519Provider)
+        kex.generateClientKeys()
+
+        val serverReply = ByteArray(1120)
+        System.arraycopy(fakeMlKemCiphertext, 0, serverReply, 0, 1088)
+        System.arraycopy(fakeX25519ServerPublic, 0, serverReply, 1088, 32)
+
+        val sharedSecret = kex.computeSharedSecret(serverReply)
+        assert(sharedSecret.isNotEmpty()) { "Shared secret should not be empty" }
+        // 4 bytes length prefix + 32 bytes SHA-256 hash
+        assertEquals(36, sharedSecret.size)
+    }
+
+    @Test
+    fun `shared secret is wire-encoded SSH string of SHA-256(mlkem_ss x25519_ss)`() {
+        val kex = MlKemHybridKeyExchange(mockMlKemProvider, mockX25519Provider)
+        kex.generateClientKeys()
+
+        val serverReply = ByteArray(1120)
+        System.arraycopy(fakeMlKemCiphertext, 0, serverReply, 0, 1088)
+        System.arraycopy(fakeX25519ServerPublic, 0, serverReply, 1088, 32)
+
+        val sharedSecret = kex.computeSharedSecret(serverReply)
+
+        val combined = fakeMlKemSharedSecret + fakeX25519SharedSecret
+        val expectedK = MessageDigest.getInstance("SHA-256").digest(combined)
+        val expectedEncoded = encodeSshString(expectedK)
+
+        assertContentEquals(expectedEncoded, sharedSecret)
+    }
+
+    @Test
+    fun `rejects server reply with wrong size`() {
+        val kex = MlKemHybridKeyExchange(mockMlKemProvider, mockX25519Provider)
+        kex.generateClientKeys()
+
+        assertFailsWith<SshException> {
+            kex.computeSharedSecret(ByteArray(100))
+        }
+    }
+
+    @Test
+    fun `rejects all-zero X25519 shared secret`() {
+        val zeroX25519Provider = object : X25519Provider {
+            override fun generatePrivateKey(): ByteArray = fakeX25519Private.clone()
+            override fun publicFromPrivate(privateKey: ByteArray): ByteArray = fakeX25519Public.clone()
+            override fun computeSharedSecret(privateKey: ByteArray, publicKey: ByteArray): ByteArray =
+                ByteArray(32) // all zeros
+        }
+
+        val kex = MlKemHybridKeyExchange(mockMlKemProvider, zeroX25519Provider)
+        kex.generateClientKeys()
+
+        val serverReply = ByteArray(1120)
+        assertFailsWith<SshException> {
+            kex.computeSharedSecret(serverReply)
+        }
+    }
+
+    @Test
+    fun `hash algorithm is SHA-256`() {
+        val kex = MlKemHybridKeyExchange(mockMlKemProvider, mockX25519Provider)
+        assertEquals("SHA-256", kex.hashAlgorithm)
+    }
+
+    @Test
+    fun `computeSharedSecret fails before generateClientKeys`() {
+        val kex = MlKemHybridKeyExchange(mockMlKemProvider, mockX25519Provider)
+        assertFailsWith<SshException> {
+            kex.computeSharedSecret(ByteArray(1120))
+        }
+    }
+}

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/RsaSignatureAlgorithmTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/RsaSignatureAlgorithmTest.kt
@@ -22,6 +22,7 @@ import org.connectbot.sshlib.struct.SshSignature
 import org.junit.Test
 import java.io.ByteArrayOutputStream
 import java.io.DataOutputStream
+import java.math.BigInteger
 import java.security.KeyPairGenerator
 import java.security.Signature
 import java.security.interfaces.RSAPublicKey
@@ -39,7 +40,7 @@ class RsaSignatureAlgorithmTest {
         encodeString(out, value.toByteArray(Charsets.US_ASCII))
     }
 
-    private fun encodeMpint(out: DataOutputStream, value: java.math.BigInteger) {
+    private fun encodeMpint(out: DataOutputStream, value: BigInteger) {
         val bytes = value.toByteArray()
         out.writeInt(bytes.size)
         out.write(bytes)


### PR DESCRIPTION
This is a huge change, but it's basically just porting the additions I made to sshlib for these algorithms over to here. It maintains the Provider type framework so that it can work on Android as well.

Some cleanup is still needed in the future to remove some duplicated utility functions, but everything is working.