### PR TITLE
Add exec channel request support (RFC 4254 §6.5)

### DIFF
--- a/sshlib/api.txt
+++ b/sshlib/api.txt
@@ -260,6 +260,7 @@ package org.connectbot.sshlib {
     method @InaccessibleFromKotlin public boolean isOpen();
     method public suspend java.lang.Object? read(kotlin.coroutines.Continuation<? super byte[]?>);
     method public suspend java.lang.Object? readExtended(kotlin.coroutines.Continuation<? super kotlin.Pair<java.lang.Integer,byte[]>?>);
+    method public suspend java.lang.Object? requestExec(java.lang.String command, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? requestPty(optional java.lang.String terminalType, optional int widthChars, optional int heightRows, optional int widthPixels, optional int heightPixels, optional byte[] terminalModes, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? requestShell(kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? resizeTerminal(int widthChars, int heightRows, int widthPixels, int heightPixels, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
@@ -343,6 +344,7 @@ package org.connectbot.sshlib.client {
     method @InaccessibleFromKotlin public boolean isOpen();
     method public suspend java.lang.Object? read(kotlin.coroutines.Continuation<? super byte[]?>);
     method public suspend java.lang.Object? readExtended(kotlin.coroutines.Continuation<? super kotlin.Pair<java.lang.Integer,byte[]>?>);
+    method public suspend java.lang.Object? requestExec(java.lang.String command, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? requestPty(java.lang.String terminalType, int widthChars, int heightRows, int widthPixels, int heightPixels, byte[] terminalModes, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? requestShell(kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? resizeTerminal(int widthChars, int heightRows, int widthPixels, int heightPixels, kotlin.coroutines.Continuation<? super java.lang.Boolean>);

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/SshSession.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/SshSession.kt
@@ -50,6 +50,17 @@ interface SshSession : AutoCloseable {
 
     suspend fun requestShell(): Boolean
 
+    /**
+     * Request execution of a command on this session channel (RFC 4254 section 6.5).
+     *
+     * Only one of [requestShell], [requestExec], or subsystem requests
+     * may succeed per session channel.
+     *
+     * @param command The command to execute on the remote server
+     * @return true if the server accepted the request
+     */
+    suspend fun requestExec(command: String): Boolean
+
     suspend fun write(data: ByteArray)
 
     suspend fun read(): ByteArray?

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SessionChannel.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SessionChannel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.runBlocking
 import org.connectbot.sshlib.SshSession
 import org.connectbot.sshlib.protocol.ByteString
+import org.connectbot.sshlib.protocol.ChannelRequestExec
 import org.connectbot.sshlib.protocol.ChannelRequestPtyReq
 import org.connectbot.sshlib.protocol.ChannelRequestShell
 import org.connectbot.sshlib.protocol.ChannelRequestWindowChange
@@ -204,6 +205,24 @@ class SessionChannel internal constructor(
             val shellReq = ChannelRequestShell()
             shellReq._check()
             msg.setRequestSpecificFields(shellReq)
+        }
+    }
+
+    override suspend fun requestExec(command: String): Boolean {
+        logger.debug("Requesting exec on channel $localChannelNumber: $command")
+        return connection.sendChannelRequest(
+            _remoteChannelNumber,
+            "exec",
+            wantReply = true
+        ) { msg ->
+            val execReq = ChannelRequestExec()
+            val cmdString = ByteString()
+            cmdString.setLenData(command.toByteArray(Charsets.UTF_8).size.toLong())
+            cmdString.setData(command.toByteArray(Charsets.UTF_8))
+            cmdString._check()
+            execReq.setCommand(cmdString)
+            execReq._check()
+            msg.setRequestSpecificFields(execReq)
         }
     }
 

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SshClientIntegrationTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SshClientIntegrationTest.kt
@@ -627,6 +627,84 @@ class SshClientIntegrationTest {
     }
 
     @Test
+    fun `should execute command with exec channel`() = runBlocking {
+        val host = opensshContainer.host
+        val port = opensshContainer.getMappedPort(22)
+
+        val config = SshClientConfig {
+            this.host = host
+            this.port = port
+            this.hostKeyVerifier = acceptAllVerifier
+        }
+        val client = SshClient(config)
+
+        try {
+            assertTrue(client.connect(), "Should connect to SSH server")
+            assertTrue(client.authenticatePassword(USERNAME, PASSWORD), "Should authenticate")
+
+            val session = client.openSession()
+            assertNotNull(session)
+
+            val execResult = session!!.requestExec("echo hello-exec")
+            assertTrue(execResult, "Should successfully request exec")
+
+            val output = withTimeout(5_000) {
+                val buf = StringBuilder()
+                while (true) {
+                    val data = session.read() ?: break
+                    buf.append(String(data))
+                }
+                buf.toString()
+            }
+
+            assertTrue(output.contains("hello-exec"), "Should receive command output: $output")
+
+            session.close()
+        } finally {
+            client.disconnect()
+        }
+    }
+
+    @Test
+    fun `should execute command with exec channel and read stderr`() = runBlocking {
+        val host = opensshContainer.host
+        val port = opensshContainer.getMappedPort(22)
+
+        val config = SshClientConfig {
+            this.host = host
+            this.port = port
+            this.hostKeyVerifier = acceptAllVerifier
+        }
+        val client = SshClient(config)
+
+        try {
+            assertTrue(client.connect(), "Should connect to SSH server")
+            assertTrue(client.authenticatePassword(USERNAME, PASSWORD), "Should authenticate")
+
+            val session = client.openSession()
+            assertNotNull(session)
+
+            val execResult = session!!.requestExec("echo error-output >&2")
+            assertTrue(execResult, "Should successfully request exec")
+
+            val stderr = withTimeout(5_000) {
+                val buf = StringBuilder()
+                while (true) {
+                    val data = session.stderr.receiveCatching().getOrNull() ?: break
+                    buf.append(String(data))
+                }
+                buf.toString()
+            }
+
+            assertTrue(stderr.contains("error-output"), "Should receive stderr output: $stderr")
+
+            session.close()
+        } finally {
+            client.disconnect()
+        }
+    }
+
+    @Test
     fun `should connect with compression enabled`() {
         val host = opensshContainer.host
         val port = opensshContainer.getMappedPort(22)


### PR DESCRIPTION
## Summary

Adds `requestExec(command: String): Boolean` to the `SshSession` interface and `SessionChannel` implementation, enabling remote command execution on session channels.

- Follows the same pattern as `requestShell()` — uses `sendChannelRequest("exec", ...)` with the existing `ChannelRequestExec` Kaitai definition
- Only one of `requestShell`, `requestExec`, or subsystem requests may succeed per session channel (per RFC 4254 §6.5)
- Integration tests verify stdout and stderr output from executed commands

## Changes

- `SshSession.kt` — added `requestExec(command: String): Boolean` to the interface
- `SessionChannel.kt` — implementation using `ChannelRequestExec` protocol message
- `SshClientIntegrationTest.kt` — two integration tests:
  - Execute command and read stdout
  - Execute command and read stderr

## Test plan

- [ ] `./gradlew :sshlib:test` — integration tests pass against OpenSSH testcontainer
- [ ] Verify exec produces correct stdout output (`echo hello-exec`)
- [ ] Verify exec produces correct stderr output (`echo error-output >&2`)