### PR TITLE
Prefer `keyboard-interactive` over `password` when authenticating

### DIFF
--- a/sshlib/api.txt
+++ b/sshlib/api.txt
@@ -181,6 +181,7 @@ package org.connectbot.sshlib {
     method @InaccessibleFromKotlin public org.connectbot.sshlib.HostKeyVerifier getHostKeyVerifier();
     method @InaccessibleFromKotlin public java.lang.String getKexAlgorithms();
     method @InaccessibleFromKotlin public java.lang.String getMacAlgorithms();
+    method @InaccessibleFromKotlin public boolean getPreferPasswordAuth();
     method @InaccessibleFromKotlin public org.connectbot.sshlib.transport.TransportFactory getTransportFactory();
     property public String clientVersion;
     property public String encryptionAlgorithms;
@@ -188,6 +189,7 @@ package org.connectbot.sshlib {
     property public org.connectbot.sshlib.HostKeyVerifier hostKeyVerifier;
     property public String kexAlgorithms;
     property public String macAlgorithms;
+    property public boolean preferPasswordAuth;
     property public org.connectbot.sshlib.transport.TransportFactory transportFactory;
     field public static final org.connectbot.sshlib.SshClientConfig.Companion Companion;
   }
@@ -205,6 +207,7 @@ package org.connectbot.sshlib {
     method @InaccessibleFromKotlin public java.lang.String getKexAlgorithms();
     method @InaccessibleFromKotlin public java.lang.String getMacAlgorithms();
     method @InaccessibleFromKotlin public int getPort();
+    method @InaccessibleFromKotlin public boolean getPreferPasswordAuth();
     method @InaccessibleFromKotlin public org.connectbot.sshlib.transport.TransportFactory? getTransportFactory();
     method @InaccessibleFromKotlin public void setClientVersion(java.lang.String);
     method @InaccessibleFromKotlin public void setEnableCompression(boolean);
@@ -216,6 +219,7 @@ package org.connectbot.sshlib {
     method @InaccessibleFromKotlin public void setKexAlgorithms(java.lang.String);
     method @InaccessibleFromKotlin public void setMacAlgorithms(java.lang.String);
     method @InaccessibleFromKotlin public void setPort(int);
+    method @InaccessibleFromKotlin public void setPreferPasswordAuth(boolean);
     method @InaccessibleFromKotlin public void setTransportFactory(org.connectbot.sshlib.transport.TransportFactory?);
     property public String clientVersion;
     property public boolean enableCompression;
@@ -227,6 +231,7 @@ package org.connectbot.sshlib {
     property public String kexAlgorithms;
     property public String macAlgorithms;
     property public int port;
+    property public boolean preferPasswordAuth;
     property public org.connectbot.sshlib.transport.TransportFactory? transportFactory;
   }
 
@@ -355,7 +360,7 @@ package org.connectbot.sshlib.client {
   }
 
   public final class SshConnection {
-    ctor public SshConnection(org.connectbot.sshlib.transport.Transport transport, optional java.lang.String clientVersion, org.connectbot.sshlib.HostKeyVerifier hostKeyVerifier, optional java.lang.String kexAlgorithms, optional java.lang.String hostKeyAlgorithms, optional java.lang.String encryptionAlgorithms, optional java.lang.String macAlgorithms, optional java.lang.String compressionAlgorithms);
+    ctor public SshConnection(org.connectbot.sshlib.transport.Transport transport, optional java.lang.String clientVersion, org.connectbot.sshlib.HostKeyVerifier hostKeyVerifier, optional java.lang.String kexAlgorithms, optional java.lang.String hostKeyAlgorithms, optional java.lang.String encryptionAlgorithms, optional java.lang.String macAlgorithms, optional java.lang.String compressionAlgorithms, optional boolean preferPasswordAuth);
     method public suspend java.lang.Object? authenticateKeyboardInteractive(java.lang.String username, org.connectbot.sshlib.KeyboardInteractiveCallback callback, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? authenticatePassword(java.lang.String username, java.lang.String password, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? close(kotlin.coroutines.Continuation<? super kotlin.Unit>);

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/SshClient.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/SshClient.kt
@@ -156,7 +156,8 @@ class SshClient private constructor(
                 hostKeyAlgorithms = config.hostKeyAlgorithms,
                 encryptionAlgorithms = config.encryptionAlgorithms,
                 macAlgorithms = config.macAlgorithms,
-                compressionAlgorithms = config.compressionAlgorithms
+                compressionAlgorithms = config.compressionAlgorithms,
+                preferPasswordAuth = config.preferPasswordAuth
             )
             val success = sshConnection.connect()
 

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/SshClientConfig.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/SshClientConfig.kt
@@ -53,6 +53,7 @@ class SshClientConfig private constructor(
     val encryptionAlgorithms: String,
     val macAlgorithms: String,
     internal val compressionAlgorithms: String,
+    val preferPasswordAuth: Boolean,
 ) {
     class Builder {
         /**
@@ -100,6 +101,12 @@ class SshClientConfig private constructor(
          */
         var enableCompression: Boolean = false
 
+        /**
+         * When true, prefer `password` over `keyboard-interactive` when both are available.
+         * By default, `keyboard-interactive` is preferred.
+         */
+        var preferPasswordAuth: Boolean = false
+
         fun build(): SshClientConfig {
             val factory = transportFactory ?: run {
                 require(host.isNotBlank()) { "Host must be specified when using default TCP transport" }
@@ -123,7 +130,8 @@ class SshClientConfig private constructor(
                 hostKeyAlgorithms,
                 encryptionAlgorithms,
                 macAlgorithms,
-                compressionAlgorithms
+                compressionAlgorithms,
+                preferPasswordAuth
             )
         }
     }

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/client/AgentChannel.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/client/AgentChannel.kt
@@ -31,11 +31,13 @@ internal class AgentChannel(
         private val logger = LoggerFactory.getLogger(AgentChannel::class.java)
     }
 
-    private var isOpen = true
+    private var _isOpen = true
     private var closeSent = false
 
+    val isOpen: Boolean get() = _isOpen
+
     suspend fun handleData(data: ByteArray) {
-        if (!isOpen) {
+        if (!_isOpen) {
             logger.warn("Received data on closed agent channel")
             return
         }
@@ -67,7 +69,7 @@ internal class AgentChannel(
                 logger.debug("Failed to send CHANNEL_CLOSE reply", e)
             }
         }
-        isOpen = false
+        _isOpen = false
     }
 
     private suspend fun sendData(data: ByteArray) {

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
@@ -594,18 +594,22 @@ class SshConnection(
         handler: AuthHandler,
         channel: Channel<AuthResult>,
     ): Boolean {
-        // Step 1: Send "none" auth to discover allowed methods
-        currentAuthMethod = "none"
-        sendAuthRequest(username, "none") {
-            val noneAuth = UserauthRequestNone().apply { _check() }
-            setMethodSpecificFields(noneAuth)
+        if (allowedAuthentications == null) {
+            // Step 1: Send "none" auth to discover allowed methods
+            currentAuthMethod = "none"
+            sendAuthRequest(username, "none") {
+                val noneAuth = UserauthRequestNone().apply { _check() }
+                setMethodSpecificFields(noneAuth)
+            }
+
+            val noneResult = channel.receive()
+            if (noneResult is AuthResult.Success) return true
+            if (noneResult !is AuthResult.Failure) return false
+
+            allowedAuthentications = noneResult.allowedMethods
         }
 
-        val noneResult = channel.receive()
-        if (noneResult is AuthResult.Success) return true
-        if (noneResult !is AuthResult.Failure) return false
-
-        val allowedMethods = noneResult.allowedMethods
+        val allowedMethods = allowedAuthentications!!
         handler.onAuthMethodsAvailable(allowedMethods)
 
         // Step 2: Public key phase
@@ -617,6 +621,9 @@ class SshConnection(
                 if (probeResult is AuthResult.PkOk) {
                     val signResult = signPublicKey(username, key, handler, channel)
                     if (signResult) return true
+                }
+                if (probeResult is AuthResult.Failure) {
+                    allowedAuthentications = probeResult.allowedMethods
                 }
                 // AuthResult.Failure → try next key
             }
@@ -709,9 +716,10 @@ class SshConnection(
         while (true) {
             when (val result = channel.receive()) {
                 is AuthResult.Success -> return true
-
-                is AuthResult.Failure -> return false
-
+                is AuthResult.Failure -> {
+                    allowedAuthentications = result.allowedMethods
+                    return false
+                }
                 is AuthResult.InfoRequest -> {
                     val responses = handler.onKeyboardInteractivePrompt(
                         result.name,
@@ -758,8 +766,12 @@ class SshConnection(
             setMethodSpecificFields(passAuth)
         }
 
-        return when (channel.receive()) {
+        return when (val result = channel.receive()) {
             is AuthResult.Success -> true
+            is AuthResult.Failure -> {
+                allowedAuthentications = result.allowedMethods
+                false
+            }
             else -> false
         }
     }

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
@@ -2031,8 +2031,9 @@ class SshConnection(
     private suspend fun checkAllChannelsClosed() {
         val allSessionsClosed = channels.values.all { !it.isOpen }
         val allForwardingClosed = forwardingChannels.values.all { !it.isOpen }
-        logger.debug("checkAllChannelsClosed: sessions=${channels.size} allSessionsClosed=$allSessionsClosed, forwarding=${forwardingChannels.size} allForwardingClosed=$allForwardingClosed")
-        if (allSessionsClosed && allForwardingClosed && channels.isNotEmpty()) {
+        val allAgentClosed = agentChannels.values.all { !it.isOpen }
+        logger.debug("checkAllChannelsClosed: sessions=${channels.size} allSessionsClosed=$allSessionsClosed, forwarding=${forwardingChannels.size} allForwardingClosed=$allForwardingClosed, agent=${agentChannels.size} allAgentClosed=$allAgentClosed")
+        if (allSessionsClosed && allForwardingClosed && allAgentClosed && channels.isNotEmpty()) {
             logger.info("All channels closed, sending disconnect")
             sendDisconnect()
         }

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
@@ -2084,6 +2084,19 @@ class SshConnection(
                 for (ch in forwardingChannels.values) {
                     ch.onClose()
                 }
+                val loopError = loopException ?: Exception("Packet loop terminated")
+                pendingAuth?.completeExceptionally(loopError)
+                pendingAuth = null
+                pendingChannelOpen?.completeExceptionally(loopError)
+                pendingChannelOpen = null
+                pendingChannelRequest?.completeExceptionally(loopError)
+                pendingChannelRequest = null
+                pendingGlobalRequest?.completeExceptionally(loopError)
+                pendingGlobalRequest = null
+                for ((_, pending) in pendingChannelOpens) {
+                    pending.deferred.completeExceptionally(loopError)
+                }
+                pendingChannelOpens.clear()
                 if (loopException != null) {
                     _disconnectedFlow.tryEmit(loopException)
                 }

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
@@ -1836,11 +1836,11 @@ class SshConnection(
             }
 
             SshEnums.MessageType.SSH_MSG_USERAUTH_SUCCESS -> {
+                dispatchEvent(SshClientStateMachine.SshEvent.AuthenticationSuccess)
                 val ch = authResultChannel
                 if (ch != null) {
                     ch.trySend(AuthResult.Success)
                 }
-                dispatchEvent(SshClientStateMachine.SshEvent.AuthenticationSuccess)
             }
 
             SshEnums.MessageType.SSH_MSG_USERAUTH_FAILURE -> {

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
@@ -139,6 +139,7 @@ class SshConnection(
     private val encryptionAlgorithms: String = CipherEntry.defaultString,
     private val macAlgorithms: String = MacEntry.defaultString,
     private val compressionAlgorithms: String = CompressionEntry.defaultString,
+    private val preferPasswordAuth: Boolean = false,
 ) {
 
     companion object {
@@ -240,6 +241,7 @@ class SshConnection(
     private var authResultChannel: Channel<AuthResult>? = null
     private var allowedAuthentications: Set<String>? = null
     private var currentAuthMethod: String? = null
+    private val triedPublicKeys = mutableSetOf<AuthPublicKey>()
 
     private var packetLoopJob: Job? = null
 
@@ -616,11 +618,15 @@ class SshConnection(
         if ("publickey" in allowedMethods) {
             val keys = handler.onPublicKeysNeeded()
             for (key in keys) {
+                if (key in triedPublicKeys) continue
                 val probeResult = probePublicKey(username, key, channel)
                 if (probeResult is AuthResult.Success) return true
                 if (probeResult is AuthResult.PkOk) {
+                    triedPublicKeys.add(key)
                     val signResult = signPublicKey(username, key, handler, channel)
                     if (signResult) return true
+                } else {
+                    triedPublicKeys.add(key)
                 }
                 if (probeResult is AuthResult.Failure) {
                     allowedAuthentications = probeResult.allowedMethods
@@ -629,17 +635,19 @@ class SshConnection(
             }
         }
 
-        // Step 3: Keyboard-interactive phase
-        if ("keyboard-interactive" in allowedMethods) {
-            val kbdResult = doKeyboardInteractive(username, handler, channel)
-            if (kbdResult) return true
-        }
+        for (method in selectPasswordMethods(allowedMethods, preferPasswordAuth)) {
+            when (method) {
+                "keyboard-interactive" -> {
+                    val kbdResult = doKeyboardInteractive(username, handler, channel)
+                    if (kbdResult) return true
+                }
 
-        // Step 4: Password phase
-        if ("password" in allowedMethods) {
-            val password = handler.onPasswordNeeded() ?: return false
-            val passResult = doPasswordAuth(username, password, channel)
-            if (passResult) return true
+                "password" -> {
+                    val password = handler.onPasswordNeeded() ?: return false
+                    val passResult = doPasswordAuth(username, password, channel)
+                    if (passResult) return true
+                }
+            }
         }
 
         return false
@@ -716,10 +724,12 @@ class SshConnection(
         while (true) {
             when (val result = channel.receive()) {
                 is AuthResult.Success -> return true
+
                 is AuthResult.Failure -> {
                     allowedAuthentications = result.allowedMethods
                     return false
                 }
+
                 is AuthResult.InfoRequest -> {
                     val responses = handler.onKeyboardInteractivePrompt(
                         result.name,
@@ -768,10 +778,12 @@ class SshConnection(
 
         return when (val result = channel.receive()) {
             is AuthResult.Success -> true
+
             is AuthResult.Failure -> {
                 allowedAuthentications = result.allowedMethods
                 false
             }
+
             else -> false
         }
     }
@@ -2229,5 +2241,28 @@ class SshConnection(
             SshEnums.MessageType.SSH_MSG_CHANNEL_CLOSE.id().toInt(),
             msg.toByteArray()
         )
+    }
+}
+
+/**
+ * Returns the list of password-based auth methods to attempt, in the order they should be tried.
+ *
+ * By default, `keyboard-interactive` is preferred when both methods are available.
+ * When [preferPasswordAuth] is true and `password` is available, `password` is tried first;
+ * `keyboard-interactive` is not tried when `password` is available and [preferPasswordAuth] is set.
+ */
+internal fun selectPasswordMethods(
+    allowedMethods: Set<String>,
+    preferPasswordAuth: Boolean,
+): List<String> {
+    val hasKbd = "keyboard-interactive" in allowedMethods
+    val hasPassword = "password" in allowedMethods
+
+    return when {
+        hasKbd && hasPassword && preferPasswordAuth -> listOf("password")
+        hasKbd && hasPassword -> listOf("keyboard-interactive")
+        hasKbd -> listOf("keyboard-interactive")
+        hasPassword -> listOf("password")
+        else -> emptyList()
     }
 }

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
@@ -238,14 +238,21 @@ class SshConnection(
 
     // Strategy-based authentication state
     private var authResultChannel: Channel<AuthResult>? = null
+    private var allowedAuthentications: Set<String>? = null
     private var currentAuthMethod: String? = null
 
     private var packetLoopJob: Job? = null
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun dispatchEvent(event: SshClientStateMachine.SshEvent) {
-        withContext(stateMachineDispatcher) {
-            stateMachine.processEvent(event)
+        logger.debug("Dispatching event: $event")
+        try {
+            withContext(stateMachineDispatcher) {
+                stateMachine.processEvent(event)
+            }
+        } catch (e: Exception) {
+            logger.error("State machine failed to process event: $event", e)
+            throw e
         }
     }
 
@@ -1263,7 +1270,7 @@ class SshConnection(
     }
 
     private fun disconnect() {
-        logger.info("Disconnecting")
+        logger.info("Disconnecting (received SSH_MSG_DISCONNECT from server)")
         _disconnectedFlow.tryEmit(null)
         runBlocking {
             transport.close()
@@ -1676,9 +1683,10 @@ class SshConnection(
      */
     private suspend fun processNextPacket() {
         val packet = packetIO.readPacket()
-        logger.debug("Received message type ${packet.messageType()}")
+        val msgType = packet.messageType()
+        logger.debug("Received packet: $msgType")
 
-        when (packet.messageType()) {
+        when (msgType) {
             SshEnums.MessageType.SSH_MSG_IGNORE -> {
                 dispatchEvent(SshClientStateMachine.SshEvent.ReceiveIgnore)
             }
@@ -1792,6 +1800,7 @@ class SshConnection(
             SshEnums.MessageType.SSH_MSG_CHANNEL_CLOSE -> {
                 val msg = parseBody<SshMsgChannelClose>(packet)
                 val recipientChannel = msg.recipientChannel().toInt()
+                logger.debug("Received CHANNEL_CLOSE for remote channel $recipientChannel (channels: ${channels.size}, forwardingChannels: ${forwardingChannels.size})")
                 val channel = channelsByRemote[recipientChannel]
                 val agentChannel = agentChannelsByRemote[recipientChannel]
                 val fwdChannel = forwardingChannelsByRemote[recipientChannel]
@@ -1900,6 +1909,8 @@ class SshConnection(
             }
 
             SshEnums.MessageType.SSH_MSG_DISCONNECT -> {
+                val msg = parseBody<SshMsgDisconnect>(packet)
+                logger.info("Received SSH_MSG_DISCONNECT from server: reason=${msg.reasonCode()}, description=${msg.description().value()}")
                 dispatchEvent(SshClientStateMachine.SshEvent.Disconnect)
             }
 
@@ -2020,6 +2031,7 @@ class SshConnection(
     private suspend fun checkAllChannelsClosed() {
         val allSessionsClosed = channels.values.all { !it.isOpen }
         val allForwardingClosed = forwardingChannels.values.all { !it.isOpen }
+        logger.debug("checkAllChannelsClosed: sessions=${channels.size} allSessionsClosed=$allSessionsClosed, forwarding=${forwardingChannels.size} allForwardingClosed=$allForwardingClosed")
         if (allSessionsClosed && allForwardingClosed && channels.isNotEmpty()) {
             logger.info("All channels closed, sending disconnect")
             sendDisconnect()
@@ -2027,6 +2039,7 @@ class SshConnection(
     }
 
     private suspend fun sendDisconnect() {
+        logger.info("Sending disconnect (client-initiated)")
         try {
             val msg = SshMsgDisconnect().apply {
                 setReasonCode(SshEnums.DisconnectReason.SSH_DISCONNECT_BY_APPLICATION)
@@ -2051,6 +2064,7 @@ class SshConnection(
             var loopException: Exception? = null
             try {
                 while (isActive) {
+                    logger.debug("Packet loop: waiting for next packet")
                     processNextPacket()
                 }
             } catch (_: CancellationException) {
@@ -2125,6 +2139,7 @@ class SshConnection(
         )
         channels[localChannelNumber] = channel
         channelsByRemote[localChannelNumber] = channel
+        logger.debug("Session channel registered: local=$localChannelNumber, remote=$remoteChannelNumber (total channels: ${channels.size})")
 
         return channel
     }

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/transport/PacketIO.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/transport/PacketIO.kt
@@ -396,6 +396,7 @@ internal class PacketIO(private val transport: Transport) {
     }
 
     private suspend fun writeRawPacket(messageType: Int, payload: ByteArray = byteArrayOf()) {
+        logger.debug("Writing packet type $messageType (seq=$sendSequenceNumber)")
         val currentAead = sendAead
         if (currentAead != null) {
             writeAeadPacket(messageType, payload, currentAead)

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SelectPasswordMethodsTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SelectPasswordMethodsTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.client
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SelectPasswordMethodsTest {
+
+    @Test
+    fun `only password offered - preferPasswordAuth false - uses password`() {
+        val result = selectPasswordMethods(setOf("password"), preferPasswordAuth = false)
+        assertEquals(listOf("password"), result)
+    }
+
+    @Test
+    fun `only password offered - preferPasswordAuth true - uses password`() {
+        val result = selectPasswordMethods(setOf("password"), preferPasswordAuth = true)
+        assertEquals(listOf("password"), result)
+    }
+
+    @Test
+    fun `only keyboard-interactive offered - preferPasswordAuth false - uses keyboard-interactive`() {
+        val result = selectPasswordMethods(setOf("keyboard-interactive"), preferPasswordAuth = false)
+        assertEquals(listOf("keyboard-interactive"), result)
+    }
+
+    @Test
+    fun `only keyboard-interactive offered - preferPasswordAuth true - uses keyboard-interactive`() {
+        val result = selectPasswordMethods(setOf("keyboard-interactive"), preferPasswordAuth = true)
+        assertEquals(listOf("keyboard-interactive"), result)
+    }
+
+    @Test
+    fun `both offered - preferPasswordAuth false - keyboard-interactive is preferred`() {
+        val result = selectPasswordMethods(setOf("keyboard-interactive", "password"), preferPasswordAuth = false)
+        assertEquals(listOf("keyboard-interactive"), result)
+    }
+
+    @Test
+    fun `both offered - preferPasswordAuth true - password is used and keyboard-interactive is skipped`() {
+        val result = selectPasswordMethods(setOf("keyboard-interactive", "password"), preferPasswordAuth = true)
+        assertEquals(listOf("password"), result)
+    }
+
+    @Test
+    fun `neither offered - returns empty`() {
+        val result = selectPasswordMethods(setOf("publickey"), preferPasswordAuth = false)
+        assertEquals(emptyList<String>(), result)
+    }
+}

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SshClientIntegrationTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SshClientIntegrationTest.kt
@@ -883,4 +883,110 @@ class SshClientIntegrationTest {
             client.disconnect()
         }
     }
+
+    @Test
+    fun `should open shell after failed then successful auth handler authenticate`() = runBlocking {
+        val host = opensshContainer.host
+        val port = opensshContainer.getMappedPort(22)
+
+        val client = SshClient(SshClientConfig {
+            this.host = host
+            this.port = port
+            this.hostKeyVerifier = acceptAllVerifier
+            // Restricted config to remove possible culprits
+            this.encryptionAlgorithms = "aes128-ctr"
+            this.macAlgorithms = "hmac-sha2-256"
+            this.kexAlgorithms = "ecdh-sha2-nistp256"
+            this.enableCompression = false
+        })
+
+        try {
+            assertTrue(client.connect(), "Should connect to SSH server")
+
+            val failingHandler = object : AuthHandler {
+                override suspend fun onPublicKeysNeeded(): List<AuthPublicKey> = emptyList()
+                override suspend fun onSignatureRequest(key: AuthPublicKey, dataToSign: ByteArray): ByteArray? = null
+                override suspend fun onKeyboardInteractivePrompt(
+                    name: String,
+                    instruction: String,
+                    prompts: List<KeyboardInteractiveCallback.Prompt>,
+                ): List<String> = prompts.map { "wrongpassword" }
+                override suspend fun onPasswordNeeded(): String? = null
+            }
+
+            val firstResult = withTimeout(10_000) { client.authenticate(USERNAME, failingHandler) }
+            assertFalse(firstResult, "First authenticate should fail with wrong password")
+            assertFalse(client.isAuthenticated, "Client should not be authenticated after first failure")
+
+            val succeedingHandler = object : AuthHandler {
+                override suspend fun onPublicKeysNeeded(): List<AuthPublicKey> = emptyList()
+                override suspend fun onSignatureRequest(key: AuthPublicKey, dataToSign: ByteArray): ByteArray? = null
+                override suspend fun onKeyboardInteractivePrompt(
+                    name: String,
+                    instruction: String,
+                    prompts: List<KeyboardInteractiveCallback.Prompt>,
+                ): List<String> = prompts.map { PASSWORD }
+                override suspend fun onPasswordNeeded(): String = PASSWORD
+            }
+
+            val secondResult = withTimeout(10_000) { client.authenticate(USERNAME, succeedingHandler) }
+            assertTrue(secondResult, "Second authenticate should succeed with correct password")
+            assertTrue(client.isAuthenticated, "Client should be authenticated after second attempt")
+
+            val session = withTimeout(10_000) { client.openSession() }
+            assertNotNull(session, "Should open session after retry authentication")
+
+            val ptyGranted = withTimeout(10_000) { session!!.requestPty() }
+            assertTrue(ptyGranted, "Should grant PTY after retry authentication")
+
+            val shellGranted = withTimeout(10_000) { session!!.requestShell() }
+            assertTrue(shellGranted, "Should spawn shell after retry authentication")
+
+            session!!.close()
+        } finally {
+            client.disconnect()
+        }
+    }
+
+    @Test
+    fun `should open shell after failed then successful authenticatePassword`() = runBlocking {
+        val host = opensshContainer.host
+        val port = opensshContainer.getMappedPort(22)
+
+        val client = SshClient(SshClientConfig {
+            this.host = host
+            this.port = port
+            this.hostKeyVerifier = acceptAllVerifier
+            // Restricted config to remove possible culprits
+            this.encryptionAlgorithms = "aes128-ctr"
+            this.macAlgorithms = "hmac-sha2-256"
+            this.kexAlgorithms = "ecdh-sha2-nistp256"
+            this.enableCompression = false
+        })
+
+        try {
+            assertTrue(client.connect(), "Should connect to SSH server")
+
+            val firstResult = withTimeout(10_000) { client.authenticatePassword(USERNAME, "wrongpassword") }
+            assertFalse(firstResult, "First authenticate should fail with wrong password")
+            assertFalse(client.isAuthenticated, "Client should not be authenticated after first failure")
+
+            val secondResult = withTimeout(10_000) { client.authenticatePassword(USERNAME, PASSWORD) }
+            assertTrue(secondResult, "Second authenticate should succeed with correct password")
+            assertTrue(client.isAuthenticated, "Client should be authenticated after second attempt")
+
+            val session = withTimeout(10_000) { client.openSession() }
+            assertNotNull(session, "Should open session after retry authentication")
+
+            val ptyGranted = withTimeout(10_000) { session!!.requestPty() }
+            assertTrue(ptyGranted, "Should grant PTY after retry authentication")
+
+            val shellGranted = withTimeout(10_000) { session!!.requestShell() }
+            assertTrue(shellGranted, "Should spawn shell after retry authentication")
+
+            session!!.close()
+        } finally {
+            client.disconnect()
+        }
+    }
 }

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SshClientIntegrationTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SshClientIntegrationTest.kt
@@ -420,11 +420,17 @@ class SshClientIntegrationTest {
         .bufferedReader().readText()
 
     @Test
-    fun `auth handler should authenticate with password fallback`() {
+    fun `auth handler should authenticate with password when preferPasswordAuth is set`() {
         val host = opensshContainer.host
         val port = opensshContainer.getMappedPort(22)
 
-        val client = BlockingSshClient(host, port, acceptAllVerifier)
+        val config = SshClientConfig {
+            this.host = host
+            this.port = port
+            this.hostKeyVerifier = acceptAllVerifier
+            this.preferPasswordAuth = true
+        }
+        val client = BlockingSshClient(config)
 
         try {
             assertTrue(client.connect(), "Should connect to SSH server")
@@ -450,7 +456,7 @@ class SshClientIntegrationTest {
             }
 
             val authenticated = client.authenticate(USERNAME, handler)
-            assertTrue(authenticated, "Should authenticate via password fallback")
+            assertTrue(authenticated, "Should authenticate via password when preferPasswordAuth is set")
             assertTrue(client.isAuthenticated, "Client should be authenticated")
             assertNotNull(methodsReceived, "Should have received available methods")
             assertTrue(methodsReceived!!.isNotEmpty(), "Available methods should not be empty")
@@ -527,7 +533,7 @@ class SshClientIntegrationTest {
     }
 
     @Test
-    fun `auth handler should fall through pubkey to keyboard-interactive to password`() {
+    fun `auth handler should fall through pubkey to keyboard-interactive`() {
         val host = opensshContainer.host
         val port = opensshContainer.getMappedPort(22)
 
@@ -558,24 +564,24 @@ class SshClientIntegrationTest {
                     name: String,
                     instruction: String,
                     prompts: List<KeyboardInteractiveCallback.Prompt>,
-                ): List<String>? {
+                ): List<String> {
                     callSequence.add("kbd")
-                    // Skip keyboard-interactive
-                    return null
+                    return prompts.map { PASSWORD }
                 }
 
-                override suspend fun onPasswordNeeded(): String {
+                override suspend fun onPasswordNeeded(): String? {
                     callSequence.add("password")
-                    return PASSWORD
+                    return null
                 }
             }
 
             val authenticated = client.authenticate(USERNAME, handler)
-            assertTrue(authenticated, "Should authenticate via password after fallthrough")
+            assertTrue(authenticated, "Should authenticate via keyboard-interactive after pubkey fallthrough")
             assertTrue(client.isAuthenticated, "Client should be authenticated")
             assertTrue("methods" in callSequence, "onAuthMethodsAvailable should have been called")
             assertTrue("pubkeys" in callSequence, "onPublicKeysNeeded should have been called")
-            assertTrue("password" in callSequence, "onPasswordNeeded should have been called")
+            assertTrue("kbd" in callSequence, "onKeyboardInteractivePrompt should have been called")
+            assertTrue("password" !in callSequence, "onPasswordNeeded should not have been called")
         } finally {
             client.disconnect()
         }
@@ -889,16 +895,18 @@ class SshClientIntegrationTest {
         val host = opensshContainer.host
         val port = opensshContainer.getMappedPort(22)
 
-        val client = SshClient(SshClientConfig {
-            this.host = host
-            this.port = port
-            this.hostKeyVerifier = acceptAllVerifier
-            // Restricted config to remove possible culprits
-            this.encryptionAlgorithms = "aes128-ctr"
-            this.macAlgorithms = "hmac-sha2-256"
-            this.kexAlgorithms = "ecdh-sha2-nistp256"
-            this.enableCompression = false
-        })
+        val client = SshClient(
+            SshClientConfig {
+                this.host = host
+                this.port = port
+                this.hostKeyVerifier = acceptAllVerifier
+                // Restricted config to remove possible culprits
+                this.encryptionAlgorithms = "aes128-ctr"
+                this.macAlgorithms = "hmac-sha2-256"
+                this.kexAlgorithms = "ecdh-sha2-nistp256"
+                this.enableCompression = false
+            }
+        )
 
         try {
             assertTrue(client.connect(), "Should connect to SSH server")
@@ -953,16 +961,18 @@ class SshClientIntegrationTest {
         val host = opensshContainer.host
         val port = opensshContainer.getMappedPort(22)
 
-        val client = SshClient(SshClientConfig {
-            this.host = host
-            this.port = port
-            this.hostKeyVerifier = acceptAllVerifier
-            // Restricted config to remove possible culprits
-            this.encryptionAlgorithms = "aes128-ctr"
-            this.macAlgorithms = "hmac-sha2-256"
-            this.kexAlgorithms = "ecdh-sha2-nistp256"
-            this.enableCompression = false
-        })
+        val client = SshClient(
+            SshClientConfig {
+                this.host = host
+                this.port = port
+                this.hostKeyVerifier = acceptAllVerifier
+                // Restricted config to remove possible culprits
+                this.encryptionAlgorithms = "aes128-ctr"
+                this.macAlgorithms = "hmac-sha2-256"
+                this.kexAlgorithms = "ecdh-sha2-nistp256"
+                this.enableCompression = false
+            }
+        )
 
         try {
             assertTrue(client.connect(), "Should connect to SSH server")

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/KeyTypesTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/KeyTypesTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import org.connectbot.sshlib.crypto.ed25519.Ed25519KeyPairGenerator
+import org.connectbot.sshlib.crypto.ed25519.Ed25519PublicKey
+import org.junit.jupiter.api.Test
+import java.security.PublicKey
+import kotlin.test.assertEquals
+
+class KeyTypesTest {
+
+    @Test
+    fun `inferKeyType recognizes OID algorithm name as Ed25519`() {
+        val original = Ed25519KeyPairGenerator().generateKeyPair().public as Ed25519PublicKey
+        val wrappedKey = object : PublicKey {
+            override fun getAlgorithm() = "1.3.101.112"
+            override fun getFormat() = original.format
+            override fun getEncoded() = original.encoded
+        }
+        assertEquals("ssh-ed25519", inferKeyType(wrappedKey))
+    }
+
+    @Test
+    fun `inferKeyType recognizes EdDSA class name`() {
+        val original = Ed25519KeyPairGenerator().generateKeyPair().public as Ed25519PublicKey
+        val wrappedKey = OpenSslEdDsaPublicKeyStub(original)
+        assertEquals("ssh-ed25519", inferKeyType(wrappedKey))
+    }
+
+    private class OpenSslEdDsaPublicKeyStub(private val delegate: PublicKey) : PublicKey {
+        override fun getAlgorithm() = "UnknownAlgorithm"
+        override fun getFormat() = delegate.format
+        override fun getEncoded() = delegate.encoded
+    }
+}

--- a/sshlib/src/test/resources/openssh-server/Dockerfile
+++ b/sshlib/src/test/resources/openssh-server/Dockerfile
@@ -49,7 +49,8 @@ RUN mkdir -p /run/openssh && \
     echo "KbdInteractiveAuthentication yes" >> /etc/ssh/sshd_config && \
     echo "UsePAM yes" >> /etc/ssh/sshd_config && \
     echo "AllowTcpForwarding yes" >> /etc/ssh/sshd_config && \
-    echo "GatewayPorts yes" >> /etc/ssh/sshd_config
+    echo "GatewayPorts yes" >> /etc/ssh/sshd_config && \
+    echo "MaxAuthTries 20" >> /etc/ssh/sshd_config
 
 # Set up public key authentication for test user
 COPY test_ed25519.pub /tmp/test_ed25519.pub
@@ -65,7 +66,7 @@ RUN mkdir -p /etc/pam.d && \
     echo "auth       required     pam_unix.so" > /etc/pam.d/sshd && \
     echo "account    required     pam_unix.so" >> /etc/pam.d/sshd && \
     echo "password   required     pam_unix.so" >> /etc/pam.d/sshd && \
-    echo "session    required     pam_unix.so" >> /etc/pam.d/sshd
+    echo "session    optional     pam_unix.so" >> /etc/pam.d/sshd
 
 EXPOSE 22
 


### PR DESCRIPTION
The current flow would try `publickey` then `keyboard-interactive` then `password`. Unforunately, this confuses the PAM subsystem if you get a password wrong twice (once for `keyboard-interactive` and once for `password`), then type the password correctly for the second `keyboard-interactive`. To avoid this apparent bug on the server side, just stick with one or the other.

Add a `SshClientConfig` preference to `preferPassword` if the client really wants to not use `keyboard-interactive`.