### PR TITLE
Add subsystem channel request support (RFC 4254 §6.5)

### DIFF
--- a/sshlib/api.txt
+++ b/sshlib/api.txt
@@ -263,6 +263,7 @@ package org.connectbot.sshlib {
     method public suspend java.lang.Object? requestExec(java.lang.String command, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? requestPty(optional java.lang.String terminalType, optional int widthChars, optional int heightRows, optional int widthPixels, optional int heightPixels, optional byte[] terminalModes, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? requestShell(kotlin.coroutines.Continuation<? super java.lang.Boolean>);
+    method public suspend java.lang.Object? requestSubsystem(java.lang.String name, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? resizeTerminal(int widthChars, int heightRows, int widthPixels, int heightPixels, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? sendEof(kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend java.lang.Object? write(byte[] data, kotlin.coroutines.Continuation<? super kotlin.Unit>);
@@ -347,6 +348,7 @@ package org.connectbot.sshlib.client {
     method public suspend java.lang.Object? requestExec(java.lang.String command, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? requestPty(java.lang.String terminalType, int widthChars, int heightRows, int widthPixels, int heightPixels, byte[] terminalModes, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? requestShell(kotlin.coroutines.Continuation<? super java.lang.Boolean>);
+    method public suspend java.lang.Object? requestSubsystem(java.lang.String name, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? resizeTerminal(int widthChars, int heightRows, int widthPixels, int heightPixels, kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend java.lang.Object? sendEof(kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend java.lang.Object? write(byte[] data, kotlin.coroutines.Continuation<? super kotlin.Unit>);

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/SshSession.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/SshSession.kt
@@ -61,6 +61,18 @@ interface SshSession : AutoCloseable {
      */
     suspend fun requestExec(command: String): Boolean
 
+    /**
+     * Request a subsystem on this session channel (RFC 4254 section 6.5).
+     *
+     * Subsystems are named services that run over an SSH channel, such as
+     * SFTP ("sftp"). Only one of [requestShell], exec, or [requestSubsystem]
+     * may succeed per session channel.
+     *
+     * @param name The subsystem name (e.g. "sftp")
+     * @return true if the server accepted the request
+     */
+    suspend fun requestSubsystem(name: String): Boolean
+
     suspend fun write(data: ByteArray)
 
     suspend fun read(): ByteArray?

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SessionChannel.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SessionChannel.kt
@@ -25,6 +25,7 @@ import org.connectbot.sshlib.protocol.ByteString
 import org.connectbot.sshlib.protocol.ChannelRequestExec
 import org.connectbot.sshlib.protocol.ChannelRequestPtyReq
 import org.connectbot.sshlib.protocol.ChannelRequestShell
+import org.connectbot.sshlib.protocol.ChannelRequestSubsystem
 import org.connectbot.sshlib.protocol.ChannelRequestWindowChange
 import org.slf4j.LoggerFactory
 
@@ -228,6 +229,24 @@ class SessionChannel internal constructor(
             execReq.setCommand(cmdString)
             execReq._check()
             msg.setRequestSpecificFields(execReq)
+        }
+    }
+
+    override suspend fun requestSubsystem(name: String): Boolean {
+        logger.debug("Requesting subsystem on channel $localChannelNumber: $name")
+        return connection.sendChannelRequest(
+            _remoteChannelNumber,
+            "subsystem",
+            wantReply = true
+        ) { msg ->
+            val subsysReq = ChannelRequestSubsystem()
+            val nameString = ByteString()
+            nameString.setLenData(name.toByteArray(Charsets.US_ASCII).size.toLong())
+            nameString.setData(name.toByteArray(Charsets.US_ASCII))
+            nameString._check()
+            subsysReq.setSubsystemName(nameString)
+            subsysReq._check()
+            msg.setRequestSpecificFields(subsysReq)
         }
     }
 

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SshClientIntegrationTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SshClientIntegrationTest.kt
@@ -718,6 +718,91 @@ class SshClientIntegrationTest {
     }
 
     @Test
+    fun `should open sftp subsystem and exchange version`() = runBlocking {
+        val host = opensshContainer.host
+        val port = opensshContainer.getMappedPort(22)
+
+        val config = SshClientConfig {
+            this.host = host
+            this.port = port
+            this.hostKeyVerifier = acceptAllVerifier
+        }
+        val client = SshClient(config)
+
+        try {
+            assertTrue(client.connect(), "Should connect to SSH server")
+            assertTrue(client.authenticatePassword(USERNAME, PASSWORD), "Should authenticate")
+
+            val session = client.openSession()
+            assertNotNull(session)
+
+            val subsystemResult = session!!.requestSubsystem("sftp")
+            assertTrue(subsystemResult, "Should successfully request sftp subsystem")
+
+            // Send SSH_FXP_INIT (type=1, length=5, version=3)
+            val initPacket = byteArrayOf(
+                0, 0, 0, 5, // length: 5 bytes (type + version)
+                1, // SSH_FXP_INIT
+                0, 0, 0, 3 // version 3
+            )
+            session.write(initPacket)
+
+            // Read SSH_FXP_VERSION response
+            val response = withTimeout(5_000) {
+                val buf = mutableListOf<Byte>()
+                while (buf.size < 9) {
+                    val data = session.read() ?: break
+                    buf.addAll(data.toList())
+                }
+                buf.toByteArray()
+            }
+
+            assertTrue(response.size >= 9, "Should receive at least 9 bytes (length + type + version)")
+            // type byte is at offset 4
+            val type = response[4].toInt() and 0xFF
+            assertTrue(type == 2, "Response type should be SSH_FXP_VERSION (2), got $type")
+            // version is at offset 5-8 (big-endian uint32)
+            val version = ((response[5].toInt() and 0xFF) shl 24) or
+                ((response[6].toInt() and 0xFF) shl 16) or
+                ((response[7].toInt() and 0xFF) shl 8) or
+                (response[8].toInt() and 0xFF)
+            assertTrue(version >= 3, "SFTP version should be >= 3, got $version")
+
+            session.close()
+        } finally {
+            client.disconnect()
+        }
+    }
+
+    @Test
+    fun `should reject unknown subsystem`() = runBlocking {
+        val host = opensshContainer.host
+        val port = opensshContainer.getMappedPort(22)
+
+        val config = SshClientConfig {
+            this.host = host
+            this.port = port
+            this.hostKeyVerifier = acceptAllVerifier
+        }
+        val client = SshClient(config)
+
+        try {
+            assertTrue(client.connect(), "Should connect to SSH server")
+            assertTrue(client.authenticatePassword(USERNAME, PASSWORD), "Should authenticate")
+
+            val session = client.openSession()
+            assertNotNull(session)
+
+            val result = session!!.requestSubsystem("nonexistent-subsystem")
+            assertFalse(result, "Should reject unknown subsystem")
+
+            session.close()
+        } finally {
+            client.disconnect()
+        }
+    }
+
+    @Test
     fun `should connect with compression enabled`() {
         val host = opensshContainer.host
         val port = opensshContainer.getMappedPort(22)


### PR DESCRIPTION
## Summary

Adds `requestSubsystem(name: String): Boolean` to the `SshSession` interface and `SessionChannel` implementation, enabling subsystem invocation (e.g. SFTP) on session channels.

This is a prerequisite for SFTP support (discussed in #96). Follows the same pattern as `requestShell()`.

## Changes

- `SshSession.kt` — added `requestSubsystem(name: String): Boolean` to the interface
- `SessionChannel.kt` — implementation using `ChannelRequestSubsystem` protocol message
- `SshClientIntegrationTest.kt` — two integration tests:
  - Open SFTP subsystem and verify SSH_FXP_INIT/SSH_FXP_VERSION exchange
  - Verify unknown subsystem is rejected by the server

## Test plan

- [ ] `./gradlew :sshlib:test` — integration tests pass against OpenSSH testcontainer
- [ ] Verify SFTP subsystem opens and responds with correct version
- [ ] Verify unknown subsystem names are rejected