### PR TITLE
chore(Base64): add compatibility class

### DIFF
--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/HostKeyVerifier.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/HostKeyVerifier.kt
@@ -16,8 +16,8 @@
 
 package org.connectbot.sshlib
 
+import org.connectbot.sshlib.crypto.Base64Compat
 import java.io.File
-import java.util.Base64
 
 /**
  * Verifies the identity of a server by checking its host key.
@@ -127,7 +127,7 @@ class KnownHostsVerifier(
         val hosts = parts[0].split(",")
         val algorithm = parts[1]
         val keyData = try {
-            Base64.getDecoder().decode(parts[2])
+            Base64Compat.decode(parts[2])
         } catch (e: IllegalArgumentException) {
             return null
         }

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/KeyFingerprint.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/KeyFingerprint.kt
@@ -16,8 +16,8 @@
 
 package org.connectbot.sshlib
 
+import org.connectbot.sshlib.crypto.Base64Compat
 import java.security.MessageDigest
-import java.util.Base64
 
 /**
  * SSH key fingerprint utilities.
@@ -46,7 +46,7 @@ object KeyFingerprint {
      */
     fun sha256(publicKeyBlob: ByteArray): String {
         val hash = MessageDigest.getInstance("SHA-256").digest(publicKeyBlob)
-        val base64 = Base64.getEncoder().encodeToString(hash).trimEnd('=')
+        val base64 = Base64Compat.encode(hash)
         return "SHA256:$base64"
     }
 

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/Base64Compat.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/Base64Compat.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+/**
+ * Base64 compatibility adapter supporting both JVM and Android API 24+.
+ *
+ * On Android below API 26, `java.util.Base64` is unavailable. This object detects
+ * `android.util.Base64` at runtime via reflection and delegates to it; otherwise
+ * falls back to `java.util.Base64`.
+ */
+internal object Base64Compat {
+
+    private val delegate: Delegate = runCatching {
+        val cls = Class.forName("android.util.Base64")
+        AndroidDelegate(cls)
+    }.getOrElse {
+        JvmDelegate()
+    }
+
+    fun encode(data: ByteArray): String = delegate.encode(data)
+
+    fun encodeWithPadding(data: ByteArray): String = delegate.encodeWithPadding(data)
+
+    fun decode(data: String): ByteArray = delegate.decode(data)
+
+    private interface Delegate {
+        fun encode(data: ByteArray): String
+        fun encodeWithPadding(data: ByteArray): String
+        fun decode(data: String): ByteArray
+    }
+
+    private class JvmDelegate : Delegate {
+        private val encoder = java.util.Base64.getEncoder()
+        private val encoderNoPad = java.util.Base64.getEncoder().withoutPadding()
+        private val decoder = java.util.Base64.getDecoder()
+
+        override fun encode(data: ByteArray): String = encoderNoPad.encodeToString(data)
+        override fun encodeWithPadding(data: ByteArray): String = encoder.encodeToString(data)
+        override fun decode(data: String): ByteArray = decoder.decode(data)
+    }
+
+    private class AndroidDelegate(cls: Class<*>) : Delegate {
+        // android.util.Base64 flag constants
+        private val NO_WRAP = cls.getField("NO_WRAP").getInt(null)
+        private val NO_PADDING = cls.getField("NO_PADDING").getInt(null)
+        private val DEFAULT = cls.getField("DEFAULT").getInt(null)
+
+        private val encodeMethod = cls.getMethod("encodeToString", ByteArray::class.java, Int::class.java)
+        private val decodeMethod = cls.getMethod("decode", String::class.java, Int::class.java)
+
+        override fun encode(data: ByteArray): String = encodeMethod.invoke(null, data, NO_WRAP or NO_PADDING) as String
+
+        override fun encodeWithPadding(data: ByteArray): String = encodeMethod.invoke(null, data, NO_WRAP) as String
+
+        override fun decode(data: String): ByteArray = decodeMethod.invoke(null, data, DEFAULT) as ByteArray
+    }
+}

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/OpenSshKeyWriter.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/OpenSshKeyWriter.kt
@@ -24,7 +24,6 @@ import java.security.interfaces.ECPrivateKey
 import java.security.interfaces.ECPublicKey
 import java.security.interfaces.RSAPrivateCrtKey
 import java.security.interfaces.RSAPublicKey
-import java.util.Base64
 
 internal object OpenSshKeyWriter {
 
@@ -210,7 +209,7 @@ internal object OpenSshKeyWriter {
     private fun formatOutput(data: ByteArray): String {
         val sb = StringBuilder()
         sb.appendLine("-----BEGIN OPENSSH PRIVATE KEY-----")
-        val base64 = Base64.getEncoder().encodeToString(data)
+        val base64 = Base64Compat.encodeWithPadding(data)
         sb.appendLine(base64.chunked(LINE_LENGTH).joinToString("\n"))
         sb.appendLine("-----END OPENSSH PRIVATE KEY-----")
         return sb.toString()

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/PemKeyReader.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/PemKeyReader.kt
@@ -30,7 +30,6 @@ import java.security.spec.NamedParameterSpec
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.RSAPrivateCrtKeySpec
 import java.security.spec.RSAPublicKeySpec
-import java.util.Base64
 
 internal object PemKeyReader {
 
@@ -121,7 +120,7 @@ internal object PemKeyReader {
             i++
         }
 
-        val data = Base64.getDecoder().decode(base64Builder.toString())
+        val data = Base64Compat.decode(base64Builder.toString())
         if (data.isEmpty()) throw SshException("Invalid PEM: no data")
 
         return PemStructure(type, data, procType, dekInfo)

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/PemKeyWriter.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/PemKeyWriter.kt
@@ -23,7 +23,6 @@ import java.security.SecureRandom
 import java.security.interfaces.ECPrivateKey
 import java.security.interfaces.ECPublicKey
 import java.security.interfaces.RSAPrivateCrtKey
-import java.util.Base64
 
 internal object PemKeyWriter {
 
@@ -136,7 +135,7 @@ internal object PemKeyWriter {
     }
 
     private fun wrapBase64(data: ByteArray): String {
-        val base64 = Base64.getEncoder().encodeToString(data)
+        val base64 = Base64Compat.encodeWithPadding(data)
         return base64.chunked(LINE_LENGTH).joinToString("\n")
     }
 }

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/PrivateKeyReader.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/crypto/PrivateKeyReader.kt
@@ -17,7 +17,6 @@
 package org.connectbot.sshlib.crypto
 
 import org.connectbot.sshlib.SshException
-import java.util.Base64
 
 internal object PrivateKeyReader {
 
@@ -28,7 +27,7 @@ internal object PrivateKeyReader {
         return when {
             trimmed.startsWith("-----BEGIN OPENSSH PRIVATE KEY-----") -> {
                 val base64 = extractBase64(trimmed, "-----BEGIN OPENSSH PRIVATE KEY-----", "-----END OPENSSH PRIVATE KEY-----")
-                val data = Base64.getDecoder().decode(base64)
+                val data = Base64Compat.decode(base64)
                 OpenSshKeyReader.read(data, passphrase)
             }
 
@@ -49,7 +48,7 @@ internal object PrivateKeyReader {
         return when {
             trimmed.startsWith("-----BEGIN OPENSSH PRIVATE KEY-----") -> {
                 val base64 = extractBase64(trimmed, "-----BEGIN OPENSSH PRIVATE KEY-----", "-----END OPENSSH PRIVATE KEY-----")
-                val data = Base64.getDecoder().decode(base64)
+                val data = Base64Compat.decode(base64)
                 OpenSshKeyReader.isEncrypted(data)
             }
 

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/Base64CompatTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/crypto/Base64CompatTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.crypto
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class Base64CompatTest {
+
+    @Test
+    fun `encode produces standard base64 without padding`() {
+        // "Man" -> "TWFu" (no padding needed)
+        val result = Base64Compat.encode("Man".toByteArray(Charsets.US_ASCII))
+        assertEquals("TWFu", result)
+    }
+
+    @Test
+    fun `encode strips padding when input length requires it`() {
+        // "Ma" -> "TWE=" in padded base64, "TWE" without
+        val result = Base64Compat.encode("Ma".toByteArray(Charsets.US_ASCII))
+        assertFalse(result.contains('='), "encode() must not contain '=' padding")
+        assertEquals("TWE", result)
+    }
+
+    @Test
+    fun `encode produces no line breaks`() {
+        val data = ByteArray(100) { it.toByte() }
+        val result = Base64Compat.encode(data)
+        assertFalse(result.contains('\n'), "encode() must not contain newlines")
+        assertFalse(result.contains('\r'), "encode() must not contain carriage returns")
+    }
+
+    @Test
+    fun `encodeWithPadding produces standard base64 with padding`() {
+        // "Ma" -> "TWE=" with padding
+        val result = Base64Compat.encodeWithPadding("Ma".toByteArray(Charsets.US_ASCII))
+        assertEquals("TWE=", result)
+    }
+
+    @Test
+    fun `encodeWithPadding produces no line breaks`() {
+        val data = ByteArray(100) { it.toByte() }
+        val result = Base64Compat.encodeWithPadding(data)
+        assertFalse(result.contains('\n'), "encodeWithPadding() must not contain newlines")
+        assertFalse(result.contains('\r'), "encodeWithPadding() must not contain carriage returns")
+    }
+
+    @Test
+    fun `decode round-trips with encode`() {
+        val original = "Hello, SSH world!".toByteArray(Charsets.UTF_8)
+        val encoded = Base64Compat.encode(original)
+        val decoded = Base64Compat.decode(encoded)
+        assertArrayEquals(original, decoded)
+    }
+
+    @Test
+    fun `decode round-trips with encodeWithPadding`() {
+        val original = "Hello, SSH world!".toByteArray(Charsets.UTF_8)
+        val encoded = Base64Compat.encodeWithPadding(original)
+        assertTrue(encoded.endsWith("=") || encoded.length % 4 == 0)
+        val decoded = Base64Compat.decode(encoded)
+        assertArrayEquals(original, decoded)
+    }
+
+    @Test
+    fun `decode handles input with padding`() {
+        val decoded = Base64Compat.decode("TWE=")
+        assertArrayEquals("Ma".toByteArray(Charsets.US_ASCII), decoded)
+    }
+
+    @Test
+    fun `decode handles input without padding`() {
+        val decoded = Base64Compat.decode("TWE")
+        assertArrayEquals("Ma".toByteArray(Charsets.US_ASCII), decoded)
+    }
+
+    @Test
+    fun `encode empty array produces empty string`() {
+        assertEquals("", Base64Compat.encode(ByteArray(0)))
+    }
+
+    @Test
+    fun `decode empty string produces empty array`() {
+        assertArrayEquals(ByteArray(0), Base64Compat.decode(""))
+    }
+}


### PR DESCRIPTION
Android API level <26 does not have the java.util.Base64 class. We need a compatibility layer to call that when needed.