### PR TITLE
feat: rekeying support

### DIFF
--- a/sshlib/api.txt
+++ b/sshlib/api.txt
@@ -304,6 +304,8 @@ package org.connectbot.sshlib {
     method @InaccessibleFromKotlin public java.lang.String getKexAlgorithms();
     method @InaccessibleFromKotlin public java.lang.String getMacAlgorithms();
     method @InaccessibleFromKotlin public boolean getPreferPasswordAuth();
+    method @InaccessibleFromKotlin public long getRekeyBytesLimit();
+    method @InaccessibleFromKotlin public long getRekeyIntervalMs();
     method @InaccessibleFromKotlin public org.connectbot.sshlib.transport.TransportFactory getTransportFactory();
     property public String clientVersion;
     property public String encryptionAlgorithms;
@@ -312,6 +314,8 @@ package org.connectbot.sshlib {
     property public String kexAlgorithms;
     property public String macAlgorithms;
     property public boolean preferPasswordAuth;
+    property public long rekeyBytesLimit;
+    property public long rekeyIntervalMs;
     property public org.connectbot.sshlib.transport.TransportFactory transportFactory;
     field public static final org.connectbot.sshlib.SshClientConfig.Companion Companion;
   }
@@ -330,6 +334,8 @@ package org.connectbot.sshlib {
     method @InaccessibleFromKotlin public java.lang.String getMacAlgorithms();
     method @InaccessibleFromKotlin public int getPort();
     method @InaccessibleFromKotlin public boolean getPreferPasswordAuth();
+    method @InaccessibleFromKotlin public long getRekeyBytesLimit();
+    method @InaccessibleFromKotlin public long getRekeyIntervalMs();
     method @InaccessibleFromKotlin public org.connectbot.sshlib.transport.TransportFactory? getTransportFactory();
     method @InaccessibleFromKotlin public void setClientVersion(java.lang.String);
     method @InaccessibleFromKotlin public void setEnableCompression(boolean);
@@ -342,6 +348,8 @@ package org.connectbot.sshlib {
     method @InaccessibleFromKotlin public void setMacAlgorithms(java.lang.String);
     method @InaccessibleFromKotlin public void setPort(int);
     method @InaccessibleFromKotlin public void setPreferPasswordAuth(boolean);
+    method @InaccessibleFromKotlin public void setRekeyBytesLimit(long);
+    method @InaccessibleFromKotlin public void setRekeyIntervalMs(long);
     method @InaccessibleFromKotlin public void setTransportFactory(org.connectbot.sshlib.transport.TransportFactory?);
     property public String clientVersion;
     property public boolean enableCompression;
@@ -354,6 +362,8 @@ package org.connectbot.sshlib {
     property public String macAlgorithms;
     property public int port;
     property public boolean preferPasswordAuth;
+    property public long rekeyBytesLimit;
+    property public long rekeyIntervalMs;
     property public org.connectbot.sshlib.transport.TransportFactory? transportFactory;
   }
 
@@ -486,7 +496,7 @@ package org.connectbot.sshlib.client {
   }
 
   public final class SshConnection {
-    ctor public SshConnection(org.connectbot.sshlib.transport.Transport transport, optional java.lang.String clientVersion, org.connectbot.sshlib.HostKeyVerifier hostKeyVerifier, optional java.lang.String kexAlgorithms, optional java.lang.String hostKeyAlgorithms, optional java.lang.String encryptionAlgorithms, optional java.lang.String macAlgorithms, optional java.lang.String compressionAlgorithms, optional boolean preferPasswordAuth);
+    ctor public SshConnection(org.connectbot.sshlib.transport.Transport transport, optional java.lang.String clientVersion, org.connectbot.sshlib.HostKeyVerifier hostKeyVerifier, optional java.lang.String kexAlgorithms, optional java.lang.String hostKeyAlgorithms, optional java.lang.String encryptionAlgorithms, optional java.lang.String macAlgorithms, optional java.lang.String compressionAlgorithms, optional boolean preferPasswordAuth, optional long rekeyIntervalMs, optional long rekeyBytesLimit, optional kotlin.coroutines.CoroutineContext coroutineContext);
     method public suspend java.lang.Object? authenticateKeyboardInteractive(java.lang.String username, org.connectbot.sshlib.KeyboardInteractiveCallback callback, kotlin.coroutines.Continuation<? super org.connectbot.sshlib.AuthResult>);
     method public suspend java.lang.Object? authenticatePassword(java.lang.String username, java.lang.String password, kotlin.coroutines.Continuation<? super org.connectbot.sshlib.AuthResult>);
     method public suspend java.lang.Object? close(kotlin.coroutines.Continuation<? super kotlin.Unit>);

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/SshClient.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/SshClient.kt
@@ -158,6 +158,8 @@ class SshClient private constructor(
             macAlgorithms = config.macAlgorithms,
             compressionAlgorithms = config.compressionAlgorithms,
             preferPasswordAuth = config.preferPasswordAuth,
+            rekeyIntervalMs = config.rekeyIntervalMs,
+            rekeyBytesLimit = config.rekeyBytesLimit,
         )
         val result = sshConnection.connect()
 

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/SshClientConfig.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/SshClientConfig.kt
@@ -54,6 +54,8 @@ class SshClientConfig private constructor(
     val macAlgorithms: String,
     internal val compressionAlgorithms: String,
     val preferPasswordAuth: Boolean,
+    val rekeyIntervalMs: Long,
+    val rekeyBytesLimit: Long,
 ) {
     class Builder {
         /**
@@ -107,6 +109,16 @@ class SshClientConfig private constructor(
          */
         var preferPasswordAuth: Boolean = false
 
+        /**
+         * Re-key after this many milliseconds. Default: 1 hour.
+         */
+        var rekeyIntervalMs: Long = 3_600_000L
+
+        /**
+         * Re-key after this many wire bytes (sent or received). Default: 1 GB.
+         */
+        var rekeyBytesLimit: Long = 1_073_741_824L
+
         fun build(): SshClientConfig {
             val factory = transportFactory ?: run {
                 require(host.isNotBlank()) { "Host must be specified when using default TCP transport" }
@@ -132,6 +144,8 @@ class SshClientConfig private constructor(
                 macAlgorithms,
                 compressionAlgorithms,
                 preferPasswordAuth,
+                rekeyIntervalMs,
+                rekeyBytesLimit,
             )
         }
     }

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/client/SshConnection.kt
@@ -26,9 +26,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -38,6 +40,7 @@ import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.connectbot.sshlib.AgentProvider
 import org.connectbot.sshlib.AuthHandler
 import org.connectbot.sshlib.AuthPublicKey
@@ -122,6 +125,7 @@ import java.math.BigInteger
 import java.security.SecureRandom
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.CoroutineContext
 import org.connectbot.sshlib.AuthResult as PublicAuthResult
 
 /**
@@ -144,6 +148,9 @@ class SshConnection(
     private val macAlgorithms: String = MacEntry.defaultString,
     private val compressionAlgorithms: String = CompressionEntry.defaultString,
     private val preferPasswordAuth: Boolean = false,
+    private val rekeyIntervalMs: Long = 3_600_000L,
+    private val rekeyBytesLimit: Long = 1_073_741_824L,
+    coroutineContext: CoroutineContext = Dispatchers.IO,
 ) {
 
     companion object {
@@ -166,6 +173,10 @@ class SshConnection(
         override suspend fun receiveKexDhReply(msg: SshMsgKexdhReply) = this@SshConnection.receiveKexDhReply(msg)
         override suspend fun receiveKexEcdhReply(msg: SshMsgKexEcdhReply) = this@SshConnection.receiveKexEcdhReply(msg)
         override suspend fun receiveKexDhGexReply(msg: SshMsgKexDhGexReply) = this@SshConnection.receiveKexDhGexReply(msg)
+        override fun isRekeying(): Boolean = this@SshConnection.isRekeying
+        override fun rekeyStarted() = this@SshConnection.rekeyStarted()
+        override fun rekeyComplete() = this@SshConnection.rekeyComplete()
+        override suspend fun sendKexDhGexInit() = this@SshConnection.sendKexDhGexInit()
         override suspend fun sendNewKeys() = this@SshConnection.sendNewKeys()
         override fun receiveNewKeys() = this@SshConnection.receiveNewKeys()
         override suspend fun activateEncryption() = this@SshConnection.activateEncryption()
@@ -191,7 +202,7 @@ class SshConnection(
     }
 
     private val stateMachine = SshClientStateMachine(callbacks)
-    private val connectionScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val connectionScope = CoroutineScope(SupervisorJob() + coroutineContext)
     private val writeMutex = Mutex()
 
     private val _disconnectedFlow = MutableSharedFlow<Throwable?>(extraBufferCapacity = 1)
@@ -307,6 +318,14 @@ class SshConnection(
 
     private var packetLoopJob: Job? = null
 
+    @Volatile private var isRekeying = false
+
+    @Volatile private var rekeyPending = false
+    private var rekeyTimerJob: Job? = null
+
+    @Volatile private var pendingConnect: CompletableDeferred<ConnectResult>? = null
+    private var dhGexGroup: SshMsgKexDhGexGroup? = null
+
     private suspend fun dispatchEvent(event: SshClientStateMachine.SshEvent) {
         logger.debug("Dispatching event: $event")
         try {
@@ -334,120 +353,41 @@ class SshConnection(
      * Returns [ConnectResult.Success] when the transport is ready for authentication calls.
      */
     suspend fun connect(): ConnectResult {
-        try {
+        val deferred = CompletableDeferred<ConnectResult>()
+        pendingConnect = deferred
+
+        return try {
             dispatchEvent(SshClientStateMachine.SshEvent.Connect)
 
-            // Version exchange
+            // Version exchange — text protocol, handled inline
             packetIO.writeBanner(clientVersion)
             val banner = packetIO.readBanner()
             dispatchEvent(SshClientStateMachine.SshEvent.ReceiveVersion(banner))
 
-            // Key exchange initialization - read server's KEXINIT
-            val kexInitPacket = packetIO.readPacket()
-            val kexInit = kexInitPacket.body() as SshMsgKexinit
-
-            // Save raw KEXINIT payload for exchange hash (message type + body)
-            val kexInitMsgType = kexInitPacket.messageType().id().toByte()
-            serverKexInit = byteArrayOf(kexInitMsgType) + kexInitPacket._raw_body()
-
-            dispatchEvent(SshClientStateMachine.SshEvent.ReceiveKexInit(kexInit))
-            // Note: ReceiveKexInit transition triggers sendKexInit() via state machine
-
-            // Key exchange - read server's reply
-            // KEX-specific messages (30-49) need special parsing based on negotiated algorithm
-            val kexReplyPacket = packetIO.readPacket()
-            val messageTypeByte = kexReplyPacket.messageType().id().toByte()
-            val rawBody = byteArrayOf(messageTypeByte) + kexReplyPacket._raw_body()
-
-            val negotiated = negotiatedKex
-                ?: throw SshException("No KEX algorithm negotiated")
-            val kexEntry = KexEntry.fromSshName(negotiated)
-                ?: throw SshException("Unknown KEX algorithm: $negotiated")
-            when (kexEntry.type) {
-                KexType.ECDH -> {
-                    val ecdhStream = ByteBufferKaitaiStream(rawBody)
-                    val ecdhPayload = KexEcdhPayload(ecdhStream)
-                    ecdhPayload._read()
-                    val ecdhReply = ecdhPayload.body() as SshMsgKexEcdhReply
-                    dispatchEvent(SshClientStateMachine.SshEvent.ReceiveKex.EcdhReply(ecdhReply))
-                }
-
-                KexType.DH -> {
-                    val kexdhStream = ByteBufferKaitaiStream(rawBody)
-                    val kexdhPayload = KexdhPayload(kexdhStream)
-                    kexdhPayload._read()
-                    val dhReply = kexdhPayload.body() as SshMsgKexdhReply
-                    dispatchEvent(SshClientStateMachine.SshEvent.ReceiveKex.DhReply(dhReply))
-                }
-
-                KexType.DH_GEX -> {
-                    // First packet is SSH_MSG_KEX_DH_GEX_GROUP
-                    val groupStream = ByteBufferKaitaiStream(rawBody)
-                    val groupPayload = KexDhGexPayload(groupStream)
-                    groupPayload._read()
-                    val group = groupPayload.body() as SshMsgKexDhGexGroup
-
-                    val dhGex = kex as DiffieHellmanGroupExchange
-                    dhGex.setGroup(
-                        BigInteger(1, group.p().body()),
-                        BigInteger(1, group.g().body()),
-                    )
-                    clientPublicKey = dhGex.generateClientKeys()
-
-                    val initMsg = SshMsgKexDhGexInit().apply {
-                        setE(createMpint(clientPublicKey!!))
-                        _check()
-                    }
-                    writePacket(
-                        SshEnums.KexDhGex.SSH_MSG_KEX_DH_GEX_INIT.id().toInt(),
-                        initMsg.toByteArray(),
-                    )
-
-                    // Second packet is SSH_MSG_KEX_DH_GEX_REPLY
-                    val replyPacket = packetIO.readPacket()
-                    val replyMsgType = replyPacket.messageType().id().toByte()
-                    val replyRawBody = byteArrayOf(replyMsgType) + replyPacket._raw_body()
-                    val replyStream = ByteBufferKaitaiStream(replyRawBody)
-                    val replyPayload = KexDhGexPayload(replyStream)
-                    replyPayload._read()
-                    val reply = replyPayload.body() as SshMsgKexDhGexReply
-                    dispatchEvent(SshClientStateMachine.SshEvent.ReceiveKex.DhGexReply(reply))
-                }
-            }
-
-            // New keys - read server's NEWKEYS
-            val newKeysPacket = packetIO.readPacket()
-            dispatchEvent(SshClientStateMachine.SshEvent.ReceiveNewKeys)
-
-            // Service request (ssh-userauth)
-            // Loop until we get SERVICE_ACCEPT (skip IGNORE/DEBUG messages)
-            val serviceAccept = readExpectedMessage<SshMsgServiceAccept>(
-                SshEnums.MessageType.SSH_MSG_SERVICE_ACCEPT,
-            )
-            dispatchEvent(
-                SshClientStateMachine.SshEvent.ReceiveServiceAccept(serviceAccept.serviceName().value()),
-            )
-
-            logger.info("SSH connection established successfully")
+            // Start packet loop — handles all binary SSH packets from here
             startPacketLoop()
-            return ConnectResult.Success
+
+            withTimeout(30_000L) {
+                deferred.await()
+            }
+        } catch (e: TimeoutCancellationException) {
+            ConnectResult.TransportError(Exception("Connection timed out"))
         } catch (e: HostKeyRejectedException) {
-            logger.error("Host key rejected")
-            return ConnectResult.HostKeyRejected(e.key)
+            ConnectResult.HostKeyRejected(e.key)
         } catch (e: SshException) {
-            logger.error("SSH connection failed", e)
-            return when {
+            when {
                 e.message?.startsWith("No matching") == true ||
                     e.message?.startsWith("No KEX") == true ||
-                    e.message?.startsWith("Unknown KEX") == true -> ConnectResult.AlgorithmMismatch(e.message ?: "Algorithm mismatch")
+                    e.message?.startsWith("Unknown KEX") == true ->
+                    ConnectResult.AlgorithmMismatch(e.message ?: "Algorithm mismatch")
 
-                e.message?.contains("host key", ignoreCase = true) == true -> ConnectResult.ProtocolError(e.message ?: "Host key error", e)
+                e.message?.contains("host key", ignoreCase = true) == true ->
+                    ConnectResult.ProtocolError(e.message ?: "Host key error", e)
 
                 else -> ConnectResult.ProtocolError(e.message ?: "Protocol error", e)
             }
         } catch (e: Exception) {
-            logger.error("SSH connection failed", e)
-            return ConnectResult.TransportError(e)
+            ConnectResult.TransportError(e)
         }
     }
 
@@ -1112,6 +1052,48 @@ class SshConnection(
         writePacket(SshEnums.KexDhGex.SSH_MSG_KEX_DH_GEX_REQUEST.id().toInt(), msg.toByteArray())
     }
 
+    private fun rekeyStarted() {
+        logger.info("Re-key started")
+        isRekeying = true
+        rekeyTimerJob?.cancel()
+    }
+
+    private fun rekeyComplete() {
+        logger.info("Re-key complete")
+        isRekeying = false
+        rekeyPending = false
+        packetIO.resetByteCounters()
+        startRekeyTimer()
+    }
+
+    private fun startRekeyTimer() {
+        rekeyTimerJob?.cancel()
+        rekeyTimerJob = connectionScope.launch {
+            delay(rekeyIntervalMs)
+            rekeyPending = true
+        }
+    }
+
+    private suspend fun sendKexDhGexInit() {
+        val group = dhGexGroup ?: throw SshException("DH-GEX group not received")
+        val dhGex = kex as? DiffieHellmanGroupExchange
+            ?: throw SshException("KEX algorithm is not DH-GEX")
+        dhGex.setGroup(
+            BigInteger(1, group.p().body()),
+            BigInteger(1, group.g().body()),
+        )
+        clientPublicKey = dhGex.generateClientKeys()
+
+        val initMsg = SshMsgKexDhGexInit().apply {
+            setE(createMpint(clientPublicKey!!))
+            _check()
+        }
+        writePacket(
+            SshEnums.KexDhGex.SSH_MSG_KEX_DH_GEX_INIT.id().toInt(),
+            initMsg.toByteArray(),
+        )
+    }
+
     private suspend fun receiveKexDhReply(msg: SshMsgKexdhReply) {
         logger.info("Received DH_REPLY from server")
         completeKex(
@@ -1172,8 +1154,6 @@ class SshConnection(
 
         val publicKey = PublicKey(keyType, serverHostKey)
 
-        serverHostKeyBlob = serverHostKey
-
         val trusted = hostKeyVerifier.verify(publicKey)
 
         if (!trusted) {
@@ -1181,6 +1161,13 @@ class SshConnection(
             throw HostKeyRejectedException(publicKey)
         }
         logger.info("Host key verified")
+
+        val existingKey = serverHostKeyBlob
+        if (existingKey != null && !serverHostKey.contentEquals(existingKey)) {
+            logger.error("Host key changed during re-key — possible MITM attack")
+            throw SshException("Host key changed during re-key")
+        }
+        serverHostKeyBlob = serverHostKey
 
         if (!SignatureVerifier.verify(serverHostKey, signature, hash)) {
             logger.error("Server signature verification failed")
@@ -1364,6 +1351,9 @@ class SshConnection(
 
     private fun receiveServiceAccept(service: String) {
         logger.info("Service accepted: $service")
+        startRekeyTimer()
+        pendingConnect?.complete(ConnectResult.Success)
+        pendingConnect = null
     }
 
     private fun startAuthentication() {
@@ -1811,6 +1801,27 @@ class SshConnection(
 
         withContext(stateMachineDispatcher) {
             when (msgType) {
+                SshEnums.MessageType.SSH_MSG_KEXINIT -> {
+                    val kexInitMsgType = msgType.id().toByte()
+                    serverKexInit = byteArrayOf(kexInitMsgType) + packet._raw_body()
+                    val kexInit = packet.body() as SshMsgKexinit
+                    if (stateMachine.isInState("PostAuthenticated")) {
+                        stateMachine.processEvent(SshClientStateMachine.SshEvent.RekeyStarted)
+                    }
+                    stateMachine.processEvent(SshClientStateMachine.SshEvent.ReceiveKexInit(kexInit))
+                }
+
+                SshEnums.MessageType.SSH_MSG_NEWKEYS -> {
+                    stateMachine.processEvent(SshClientStateMachine.SshEvent.ReceiveNewKeys)
+                }
+
+                SshEnums.MessageType.SSH_MSG_SERVICE_ACCEPT -> {
+                    val msg = parseBody<SshMsgServiceAccept>(packet)
+                    stateMachine.processEvent(
+                        SshClientStateMachine.SshEvent.ReceiveServiceAccept(msg.serviceName().value()),
+                    )
+                }
+
                 SshEnums.MessageType.SSH_MSG_IGNORE -> {
                     stateMachine.processEvent(SshClientStateMachine.SshEvent.ReceiveIgnore)
                 }
@@ -2031,73 +2042,60 @@ class SshConnection(
                 }
 
                 else -> {
-                    logger.warn("Unhandled message type: ${packet.messageType()}")
+                    // KEX-specific messages 30-49 are not in MessageType enum.
+                    // Disambiguate by negotiated KEX type since ECDH reply, DH reply,
+                    // and DH-GEX group all share message ID 31.
+                    val msgId = msgType.id().toInt()
+                    val rawBody = byteArrayOf(msgType.id().toByte()) + packet._raw_body()
+                    val kexEntry = negotiatedKex?.let { KexEntry.fromSshName(it) }
+                    when {
+                        kexEntry?.type == KexType.ECDH &&
+                            msgId == SshEnums.KexEcdh.SSH_MSG_KEX_ECDH_REPLY.id().toInt() -> {
+                            val stream = ByteBufferKaitaiStream(rawBody)
+                            val ecdhPayload = KexEcdhPayload(stream)
+                            ecdhPayload._read()
+                            val ecdhReply = ecdhPayload.body() as SshMsgKexEcdhReply
+                            stateMachine.processEvent(SshClientStateMachine.SshEvent.ReceiveKex.EcdhReply(ecdhReply))
+                        }
+
+                        kexEntry?.type == KexType.DH &&
+                            msgId == SshEnums.KexDh.SSH_MSG_KEXDH_REPLY.id().toInt() -> {
+                            val stream = ByteBufferKaitaiStream(rawBody)
+                            val kexdhPayload = KexdhPayload(stream)
+                            kexdhPayload._read()
+                            val dhReply = kexdhPayload.body() as SshMsgKexdhReply
+                            stateMachine.processEvent(SshClientStateMachine.SshEvent.ReceiveKex.DhReply(dhReply))
+                        }
+
+                        kexEntry?.type == KexType.DH_GEX &&
+                            msgId == SshEnums.KexDhGex.SSH_MSG_KEX_DH_GEX_GROUP.id().toInt() -> {
+                            val stream = ByteBufferKaitaiStream(rawBody)
+                            val payload = KexDhGexPayload(stream)
+                            payload._read()
+                            val group = payload.body() as SshMsgKexDhGexGroup
+                            dhGexGroup = group
+                            stateMachine.processEvent(SshClientStateMachine.SshEvent.ReceiveKex.DhGexGroup(group))
+                        }
+
+                        kexEntry?.type == KexType.DH_GEX &&
+                            msgId == SshEnums.KexDhGex.SSH_MSG_KEX_DH_GEX_REPLY.id().toInt() -> {
+                            val stream = ByteBufferKaitaiStream(rawBody)
+                            val replyPayload = KexDhGexPayload(stream)
+                            replyPayload._read()
+                            val reply = replyPayload.body() as SshMsgKexDhGexReply
+                            stateMachine.processEvent(SshClientStateMachine.SshEvent.ReceiveKex.DhGexReply(reply))
+                        }
+
+                        else -> {
+                            logger.warn("Unhandled message type: ${packet.messageType()}")
+                        }
+                    }
                 }
             }
         }
     }
 
     // Helper methods for SSH protocol encoding
-
-    /**
-     * Read packets until we get the expected message type, skipping IGNORE/DEBUG messages.
-     */
-    private suspend inline fun <reified T> readExpectedMessage(expectedType: SshEnums.MessageType): T {
-        while (true) {
-            val packet = packetIO.readPacket()
-            val messageType = packet.messageType()
-
-            when (messageType) {
-                SshEnums.MessageType.SSH_MSG_IGNORE -> {
-                    logger.debug("Received SSH_MSG_IGNORE, skipping")
-                    continue
-                }
-
-                SshEnums.MessageType.SSH_MSG_DEBUG -> {
-                    logger.debug("Received SSH_MSG_DEBUG, skipping")
-                    continue
-                }
-
-                expectedType -> {
-                    return packet.body() as T
-                }
-
-                else -> {
-                    throw SshException("Expected $expectedType but got $messageType")
-                }
-            }
-        }
-    }
-
-    /**
-     * Read packets until we get one of the expected message types, skipping IGNORE/DEBUG messages.
-     */
-    private suspend inline fun <reified T> readExpectedMessage(vararg expectedTypes: SshEnums.MessageType): T {
-        while (true) {
-            val packet = packetIO.readPacket()
-            val messageType = packet.messageType()
-
-            when (messageType) {
-                SshEnums.MessageType.SSH_MSG_IGNORE -> {
-                    logger.debug("Received SSH_MSG_IGNORE, skipping")
-                    continue
-                }
-
-                SshEnums.MessageType.SSH_MSG_DEBUG -> {
-                    logger.debug("Received SSH_MSG_DEBUG, skipping")
-                    continue
-                }
-
-                in expectedTypes -> {
-                    return packet as T
-                }
-
-                else -> {
-                    throw SshException("Expected one of ${expectedTypes.joinToString()} but got $messageType")
-                }
-            }
-        }
-    }
 
     private inline fun <reified T : KaitaiStruct.ReadWrite> parseBody(packet: UnencryptedPacket.UnencryptedPayload): T {
         val rawBody = packet._raw_body()
@@ -2184,10 +2182,20 @@ class SshConnection(
                 while (isActive) {
                     logger.debug("Packet loop: waiting for next packet")
                     processNextPacket()
+                    if (!isRekeying && stateMachine.isInState("PostAuthenticated") && (
+                            rekeyPending ||
+                                packetIO.bytesSentOnWire >= rekeyBytesLimit ||
+                                packetIO.bytesReceivedOnWire >= rekeyBytesLimit
+                            )
+                    ) {
+                        dispatchEvent(SshClientStateMachine.SshEvent.RekeyStarted)
+                    }
                 }
             } catch (_: CancellationException) {
                 logger.debug("Packet loop cancelled")
             } catch (e: Exception) {
+                pendingConnect?.completeExceptionally(e)
+                pendingConnect = null
                 val allClosed = channels.values.all { !it.isOpen }
                 if (allClosed) {
                     logger.debug("Packet loop ended (all channels closed)")

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/protocol/SshClientStateMachine.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/protocol/SshClientStateMachine.kt
@@ -17,8 +17,11 @@
 package org.connectbot.sshlib.protocol
 
 import ru.nsk.kstatemachine.event.Event
+import ru.nsk.kstatemachine.state.HistoryState
+import ru.nsk.kstatemachine.state.HistoryType
 import ru.nsk.kstatemachine.state.activeStates
 import ru.nsk.kstatemachine.state.finalState
+import ru.nsk.kstatemachine.state.historyState
 import ru.nsk.kstatemachine.state.initialState
 import ru.nsk.kstatemachine.state.invoke
 import ru.nsk.kstatemachine.state.onEntry
@@ -40,10 +43,10 @@ import ru.nsk.kstatemachine.transition.onTriggered
  * - WaitVersion: Waiting for server version/banner
  * - WaitKexInit: Waiting for server's KEX initialization
  * - WaitKex: Waiting for key exchange messages (DH, ECDH, etc.)
+ * - WaitKexDhGexInit: Waiting for DH-GEX reply after sending SSH_MSG_KEX_DH_GEX_INIT
  * - WaitNewKeys: Waiting for SSH_MSG_NEWKEYS from server
  * - WaitService: Waiting for service acceptance
- * - WaitAuthentication: Waiting for authentication success
- * - Connected: Fully authenticated and connected
+ * - PostAuthenticated: Compound state for all post-auth states (Authenticated, ChannelOpen, etc.)
  * - Disconnected: Connection terminated
  *
  * Note: This state machine is designed for SSH clients only. For server-side
@@ -59,6 +62,7 @@ internal class SshClientStateMachine(
         sealed class ReceiveKex : SshEvent() {
             data class DhReply(val msg: SshMsgKexdhReply) : ReceiveKex()
             data class EcdhReply(val msg: SshMsgKexEcdhReply) : ReceiveKex()
+            data class DhGexGroup(val msg: SshMsgKexDhGexGroup) : ReceiveKex()
             data class DhGexReply(val msg: SshMsgKexDhGexReply) : ReceiveKex()
         }
         object ReceiveNewKeys : SshEvent()
@@ -87,20 +91,102 @@ internal class SshClientStateMachine(
         data class ReceiveDebug(val msg: SshMsgDebug) : SshEvent()
         object ReceiveIgnore : SshEvent()
         object Disconnect : SshEvent()
+        object RekeyStarted : SshEvent()
     }
 
     val stateMachine: StateMachine = createStdLibStateMachine {
         val waitVersion = state("WaitVersion")
         val waitKexInit = state("WaitKexInit")
         val waitKex = state("WaitKex")
+        val waitKexDhGexInit = state("WaitKexDhGexInit")
         val waitNewKeys = state("WaitNewKeys")
         val waitService = state("WaitService")
-        val waitAuthentication = state("WaitAuthentication")
-        val authenticated = state("Authenticated")
-        val waitChannelOpenConfirmation = state("WaitChannelOpenConfirmation")
-        val channelOpen = state("ChannelOpen")
-        val waitChannelRequestReply = state("WaitChannelRequestReply")
         val disconnected = finalState("Disconnected")
+
+        lateinit var postAuthHistory: HistoryState
+
+        val postAuthenticated = state("PostAuthenticated") {
+            val authenticated = initialState("Authenticated")
+            val waitChannelOpenConfirmation = state("WaitChannelOpenConfirmation")
+            val channelOpen = state("ChannelOpen")
+            val waitChannelRequestReply = state("WaitChannelRequestReply")
+
+            authenticated {
+                onEntry { callbacks.onStateEnter("Authenticated") }
+                onExit { callbacks.onStateExit("Authenticated") }
+
+                transition<SshEvent.OpenChannel> {
+                    targetState = waitChannelOpenConfirmation
+                    onTriggered {
+                        callbacks.sendChannelOpen(
+                            it.event.channelType,
+                            it.event.localChannelNumber,
+                            it.event.initialWindowSize,
+                            it.event.maxPacketSize,
+                        )
+                    }
+                }
+            }
+
+            waitChannelOpenConfirmation {
+                onEntry { callbacks.onStateEnter("WaitChannelOpenConfirmation") }
+                onExit { callbacks.onStateExit("WaitChannelOpenConfirmation") }
+
+                transition<SshEvent.ReceiveChannelOpenConfirmation> {
+                    targetState = channelOpen
+                    onTriggered { callbacks.receiveChannelOpenConfirmation(it.event.msg) }
+                }
+                transition<SshEvent.ReceiveChannelOpenFailure> {
+                    targetState = authenticated
+                    onTriggered { callbacks.receiveChannelOpenFailure(it.event.msg) }
+                }
+            }
+
+            channelOpen {
+                onEntry { callbacks.onStateEnter("ChannelOpen") }
+                onExit { callbacks.onStateExit("ChannelOpen") }
+
+                transition<SshEvent.SendChannelRequest> {
+                    targetState = waitChannelRequestReply
+                    onTriggered {
+                        callbacks.sendChannelRequest(
+                            it.event.recipientChannel,
+                            it.event.requestType,
+                            it.event.wantReply,
+                            it.event.message,
+                        )
+                    }
+                }
+            }
+
+            waitChannelRequestReply {
+                onEntry { callbacks.onStateEnter("WaitChannelRequestReply") }
+                onExit { callbacks.onStateExit("WaitChannelRequestReply") }
+
+                transition<SshEvent.ReceiveChannelSuccess> {
+                    targetState = channelOpen
+                    onTriggered { callbacks.receiveChannelSuccess() }
+                }
+                transition<SshEvent.ReceiveChannelFailure> {
+                    targetState = channelOpen
+                    onTriggered { callbacks.receiveChannelFailure() }
+                }
+            }
+
+            postAuthHistory = historyState(
+                name = "PostAuthHistory",
+                defaultState = authenticated,
+                historyType = HistoryType.SHALLOW,
+            )
+
+            transition<SshEvent.RekeyStarted> {
+                targetState = waitKexInit
+                onTriggered {
+                    callbacks.rekeyStarted()
+                    callbacks.sendKexInit()
+                }
+            }
+        }
 
         initialState("Unconnected") {
             onEntry { callbacks.onStateEnter("Unconnected") }
@@ -108,9 +194,7 @@ internal class SshClientStateMachine(
 
             transition<SshEvent.Connect> {
                 targetState = waitVersion
-                onTriggered {
-                    callbacks.sendVersion()
-                }
+                onTriggered { callbacks.sendVersion() }
             }
         }
 
@@ -151,7 +235,6 @@ internal class SshClientStateMachine(
                     callbacks.sendNewKeys()
                 }
             }
-
             transition<SshEvent.ReceiveKex.EcdhReply> {
                 targetState = waitNewKeys
                 onTriggered {
@@ -159,6 +242,15 @@ internal class SshClientStateMachine(
                     callbacks.sendNewKeys()
                 }
             }
+            transition<SshEvent.ReceiveKex.DhGexGroup> {
+                targetState = waitKexDhGexInit
+                onTriggered { callbacks.sendKexDhGexInit() }
+            }
+        }
+
+        waitKexDhGexInit {
+            onEntry { callbacks.onStateEnter("WaitKexDhGexInit") }
+            onExit { callbacks.onStateExit("WaitKexDhGexInit") }
 
             transition<SshEvent.ReceiveKex.DhGexReply> {
                 targetState = waitNewKeys
@@ -174,11 +266,21 @@ internal class SshClientStateMachine(
             onExit { callbacks.onStateExit("WaitNewKeys") }
 
             transition<SshEvent.ReceiveNewKeys> {
+                guard = { !callbacks.isRekeying() }
                 targetState = waitService
                 onTriggered {
                     callbacks.receiveNewKeys()
                     callbacks.activateEncryption()
                     callbacks.sendServiceRequest("ssh-userauth")
+                }
+            }
+            transition<SshEvent.ReceiveNewKeys> {
+                guard = { callbacks.isRekeying() }
+                targetState = postAuthHistory
+                onTriggered {
+                    callbacks.receiveNewKeys()
+                    callbacks.activateEncryption()
+                    callbacks.rekeyComplete()
                 }
             }
         }
@@ -188,7 +290,7 @@ internal class SshClientStateMachine(
             onExit { callbacks.onStateExit("WaitService") }
 
             transition<SshEvent.ReceiveServiceAccept> {
-                targetState = waitAuthentication
+                targetState = postAuthenticated
                 onTriggered {
                     callbacks.receiveServiceAccept(it.event.service)
                     callbacks.startAuthentication()
@@ -196,125 +298,30 @@ internal class SshClientStateMachine(
             }
         }
 
-        waitAuthentication {
-            onEntry { callbacks.onStateEnter("WaitAuthentication") }
-            onExit { callbacks.onStateExit("WaitAuthentication") }
-
-            transition<SshEvent.AuthenticationSuccess> {
-                targetState = authenticated
-                onTriggered {
-                    callbacks.authenticationSuccess()
-                }
-            }
-
-            transition<SshEvent.AuthenticationFailure> {
-                onTriggered {
-                    callbacks.authenticationFailure()
-                }
-            }
-
-            transition<SshEvent.ReceiveUserauthInfoRequest> {
-                onTriggered {
-                    callbacks.receiveUserauthInfoRequest(it.event.msg)
-                }
-            }
-
-            transition<SshEvent.ReceiveUserauthBanner> {
-                onTriggered {
-                    callbacks.receiveUserauthBanner(it.event.msg)
-                }
-            }
+        transition<SshEvent.AuthenticationSuccess> {
+            onTriggered { callbacks.authenticationSuccess() }
         }
-
-        authenticated {
-            onEntry { callbacks.onStateEnter("Authenticated") }
-            onExit { callbacks.onStateExit("Authenticated") }
-
-            transition<SshEvent.OpenChannel> {
-                targetState = waitChannelOpenConfirmation
-                onTriggered {
-                    callbacks.sendChannelOpen(it.event.channelType, it.event.localChannelNumber, it.event.initialWindowSize, it.event.maxPacketSize)
-                }
-            }
+        transition<SshEvent.AuthenticationFailure> {
+            onTriggered { callbacks.authenticationFailure() }
         }
-
-        waitChannelOpenConfirmation {
-            onEntry { callbacks.onStateEnter("WaitChannelOpenConfirmation") }
-            onExit { callbacks.onStateExit("WaitChannelOpenConfirmation") }
-
-            transition<SshEvent.ReceiveChannelOpenConfirmation> {
-                targetState = channelOpen
-                onTriggered {
-                    callbacks.receiveChannelOpenConfirmation(it.event.msg)
-                }
-            }
-
-            transition<SshEvent.ReceiveChannelOpenFailure> {
-                targetState = authenticated
-                onTriggered {
-                    callbacks.receiveChannelOpenFailure(it.event.msg)
-                }
-            }
+        transition<SshEvent.ReceiveUserauthInfoRequest> {
+            onTriggered { callbacks.receiveUserauthInfoRequest(it.event.msg) }
         }
-
-        channelOpen {
-            onEntry { callbacks.onStateEnter("ChannelOpen") }
-            onExit { callbacks.onStateExit("ChannelOpen") }
-
-            transition<SshEvent.SendChannelRequest> {
-                targetState = waitChannelRequestReply
-                onTriggered {
-                    callbacks.sendChannelRequest(it.event.recipientChannel, it.event.requestType, it.event.wantReply, it.event.message)
-                }
-            }
+        transition<SshEvent.ReceiveUserauthBanner> {
+            onTriggered { callbacks.receiveUserauthBanner(it.event.msg) }
         }
-
-        waitChannelRequestReply {
-            onEntry { callbacks.onStateEnter("WaitChannelRequestReply") }
-            onExit { callbacks.onStateExit("WaitChannelRequestReply") }
-
-            transition<SshEvent.ReceiveChannelSuccess> {
-                targetState = channelOpen
-                onTriggered {
-                    callbacks.receiveChannelSuccess()
-                }
-            }
-
-            transition<SshEvent.ReceiveChannelFailure> {
-                targetState = channelOpen
-                onTriggered {
-                    callbacks.receiveChannelFailure()
-                }
-            }
-        }
-
-        disconnected {
-            onEntry { callbacks.onStateEnter("Disconnected") }
-        }
-
         transition<SshEvent.ReceiveDebug> {
-            onTriggered {
-                callbacks.debug(it.event.msg)
-            }
+            onTriggered { callbacks.debug(it.event.msg) }
         }
-
         transition<SshEvent.ReceiveIgnore> {
-            onTriggered {
-                callbacks.ignore()
-            }
+            onTriggered { callbacks.ignore() }
         }
-
         transition<SshEvent.ReceiveGlobalRequest> {
-            onTriggered {
-                callbacks.receiveGlobalRequest(it.event.msg)
-            }
+            onTriggered { callbacks.receiveGlobalRequest(it.event.msg) }
         }
-
         transition<SshEvent.Disconnect> {
             targetState = disconnected
-            onTriggered {
-                callbacks.disconnect()
-            }
+            onTriggered { callbacks.disconnect() }
         }
     }
 
@@ -337,6 +344,10 @@ internal interface SshClientCallbacks {
     suspend fun receiveKexDhReply(msg: SshMsgKexdhReply)
     suspend fun receiveKexEcdhReply(msg: SshMsgKexEcdhReply)
     suspend fun receiveKexDhGexReply(msg: SshMsgKexDhGexReply)
+    fun isRekeying(): Boolean
+    fun rekeyStarted()
+    fun rekeyComplete()
+    suspend fun sendKexDhGexInit()
     suspend fun sendNewKeys()
     fun receiveNewKeys()
     suspend fun activateEncryption()

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/transport/PacketIO.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/transport/PacketIO.kt
@@ -75,6 +75,10 @@ internal class PacketIO(private val transport: Transport) {
     private var sendCompressionActive: Boolean = false
     private var receiveCompressionActive: Boolean = false
 
+    // Wire-byte counters for re-key threshold tracking
+    internal var bytesSentOnWire: Long = 0L
+    internal var bytesReceivedOnWire: Long = 0L
+
     /**
      * Enable encryption and MAC for subsequent packets.
      *
@@ -161,6 +165,11 @@ internal class PacketIO(private val transport: Transport) {
         if (receiveCompressor != null) receiveCompressionActive = true
     }
 
+    fun resetByteCounters() {
+        bytesSentOnWire = 0L
+        bytesReceivedOnWire = 0L
+    }
+
     /**
      * Read and parse the next SSH packet, decompressing if compression is active.
      *
@@ -235,6 +244,7 @@ internal class PacketIO(private val transport: Transport) {
     private suspend fun readUnencryptedPacketBytes(): ByteArray {
         // Read packet_length (4 bytes)
         val lengthBytes = transport.read(4)
+        bytesReceivedOnWire += 4
         val packetLength = ByteBuffer.wrap(lengthBytes).int
 
         if (packetLength < MIN_PACKET_LENGTH || packetLength > MAX_PACKET_LENGTH) {
@@ -243,6 +253,7 @@ internal class PacketIO(private val transport: Transport) {
 
         // Read rest of packet
         val packetData = transport.read(packetLength)
+        bytesReceivedOnWire += packetLength
 
         receiveSequenceNumber++
         val fullPacket = lengthBytes + packetData
@@ -255,6 +266,7 @@ internal class PacketIO(private val transport: Transport) {
 
         // Read first block (contains packet_length)
         val firstBlock = transport.read(blockSize)
+        bytesReceivedOnWire += blockSize
         val decryptedFirst = cipher.decrypt(firstBlock)
 
         // Extract packet_length
@@ -267,13 +279,14 @@ internal class PacketIO(private val transport: Transport) {
         // Read remaining encrypted data
         val remainingLength = packetLength - blockSize + 4
         val remainingData = if (remainingLength.compareTo(0) > 0) {
-            transport.read(remainingLength)
+            transport.read(remainingLength).also { bytesReceivedOnWire += remainingLength }
         } else {
             byteArrayOf()
         }
 
         // Read MAC
         val receivedMac = transport.read(macLength)
+        bytesReceivedOnWire += macLength
 
         // Decrypt remaining data
         val decryptedRemaining = if (remainingData.isNotEmpty()) {
@@ -310,6 +323,7 @@ internal class PacketIO(private val transport: Transport) {
 
         // In ETM mode, length is NOT encrypted
         val lengthBytes = transport.read(4)
+        bytesReceivedOnWire += 4
         val encryptedLength = ByteBuffer.wrap(lengthBytes).int
 
         if (encryptedLength < MIN_PACKET_LENGTH || encryptedLength > MAX_PACKET_LENGTH) {
@@ -318,9 +332,11 @@ internal class PacketIO(private val transport: Transport) {
 
         // Read encrypted payload
         val encryptedPayload = transport.read(encryptedLength)
+        bytesReceivedOnWire += encryptedLength
 
         // Read MAC
         val receivedMac = transport.read(macLength)
+        bytesReceivedOnWire += macLength
 
         // Verify MAC (over sequence_number || length || encrypted_payload)
         val expectedMac = mac.computeEtm(receiveSequenceNumber, encryptedLength, encryptedPayload)
@@ -351,6 +367,7 @@ internal class PacketIO(private val transport: Transport) {
      */
     private suspend fun readAeadPacketBytes(aead: PacketAead): ByteArray {
         val wireLength = transport.read(4)
+        bytesReceivedOnWire += 4
 
         val lengthBytes: ByteArray
         val aadBytes: ByteArray
@@ -369,7 +386,9 @@ internal class PacketIO(private val transport: Transport) {
         }
 
         val ciphertext = transport.read(packetLength)
+        bytesReceivedOnWire += packetLength
         val tag = transport.read(aead.tagLength)
+        bytesReceivedOnWire += aead.tagLength
 
         val plaintext = aead.decrypt(aadBytes, ciphertext, tag)
 
@@ -442,7 +461,9 @@ internal class PacketIO(private val transport: Transport) {
         val padding = Random.nextBytes(paddingLength)
         buffer.write(padding)
 
-        transport.write(buffer.toByteArray())
+        val data = buffer.toByteArray()
+        transport.write(data)
+        bytesSentOnWire += data.size
         sendSequenceNumber++
     }
 
@@ -487,7 +508,9 @@ internal class PacketIO(private val transport: Transport) {
         val encryptedPacket = cipher.encrypt(unencryptedPacket)
 
         // Send encrypted packet + MAC
-        transport.write(encryptedPacket + macBytes)
+        val data = encryptedPacket + macBytes
+        transport.write(data)
+        bytesSentOnWire += data.size
         sendSequenceNumber++
     }
 
@@ -528,7 +551,9 @@ internal class PacketIO(private val transport: Transport) {
 
         // Build final packet: length (unencrypted) + encrypted_payload + MAC
         val lengthBytes = ByteBuffer.allocate(4).putInt(packetLength).array()
-        transport.write(lengthBytes + encryptedPayload + macBytes)
+        val data = lengthBytes + encryptedPayload + macBytes
+        transport.write(data)
+        bytesSentOnWire += data.size
         sendSequenceNumber++
     }
 
@@ -575,7 +600,9 @@ internal class PacketIO(private val transport: Transport) {
 
         val result = aead.encrypt(aadBytes, plaintext)
 
-        transport.write(wireLength + result.ciphertext + result.tag)
+        val data = wireLength + result.ciphertext + result.tag
+        transport.write(data)
+        bytesSentOnWire += data.size
         sendSequenceNumber++
     }
 

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/SshClientTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/SshClientTest.kt
@@ -18,6 +18,7 @@ package org.connectbot.sshlib
 
 import kotlinx.coroutines.test.runTest
 import org.connectbot.sshlib.transport.TransportFactory
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import kotlin.test.assertIs
 import kotlin.test.assertNull
@@ -115,5 +116,31 @@ class SshClientTest {
     fun `connectionInfo is null before connect`() {
         val client = clientWithHost("host")
         assertNull(client.connectionInfo)
+    }
+
+    @Test
+    fun `SshClientConfig has default rekey thresholds`() {
+        val config = SshClientConfig {
+            host = "example.com"
+            hostKeyVerifier = object : HostKeyVerifier {
+                override suspend fun verify(key: PublicKey): Boolean = true
+            }
+        }
+        assertEquals(3_600_000L, config.rekeyIntervalMs)
+        assertEquals(1_073_741_824L, config.rekeyBytesLimit)
+    }
+
+    @Test
+    fun `SshClientConfig custom rekey thresholds are applied`() {
+        val config = SshClientConfig {
+            host = "example.com"
+            hostKeyVerifier = object : HostKeyVerifier {
+                override suspend fun verify(key: PublicKey): Boolean = true
+            }
+            rekeyIntervalMs = 60_000L
+            rekeyBytesLimit = 1024L
+        }
+        assertEquals(60_000L, config.rekeyIntervalMs)
+        assertEquals(1024L, config.rekeyBytesLimit)
     }
 }

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/client/FakeSshServer.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/client/FakeSshServer.kt
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.client
+
+import io.kaitai.struct.ByteBufferKaitaiStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.connectbot.sshlib.crypto.CipherEntry
+import org.connectbot.sshlib.crypto.EncryptionInstance
+import org.connectbot.sshlib.crypto.KeyDerivation
+import org.connectbot.sshlib.crypto.MacEntry
+import org.connectbot.sshlib.crypto.SshPublicKeyEncoder
+import org.connectbot.sshlib.crypto.X25519ProviderFactory
+import org.connectbot.sshlib.crypto.encodeMpint
+import org.connectbot.sshlib.protocol.SshEnums
+import org.connectbot.sshlib.protocol.SshMsgKexEcdhInit
+import org.connectbot.sshlib.protocol.SshMsgKexEcdhReply
+import org.connectbot.sshlib.protocol.SshMsgKexinit
+import org.connectbot.sshlib.protocol.SshMsgServiceAccept
+import org.connectbot.sshlib.protocol.createAsciiString
+import org.connectbot.sshlib.protocol.createByteString
+import org.connectbot.sshlib.protocol.createNameList
+import org.connectbot.sshlib.protocol.toByteArray
+import org.connectbot.sshlib.transport.PacketIO
+import org.connectbot.sshlib.transport.PipedTransport
+import java.math.BigInteger
+import java.nio.ByteBuffer
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+class FakeSshServer(
+    private val serverTransport: PipedTransport,
+    private val scope: CoroutineScope,
+) {
+    @Volatile
+    var rekeyCount = 0
+        private set
+
+    private val hostKeyPair: KeyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair()
+    private val hostKeyBlob: ByteArray = SshPublicKeyEncoder.encode(hostKeyPair.public, "ssh-ed25519")
+
+    private lateinit var serverIo: PacketIO
+    private lateinit var clientVersionStr: String
+    private val serverVersionStr = "SSH-2.0-FakeServer_1.0"
+    private val writeMutex = Mutex()
+
+    private var sessionId: ByteArray? = null
+    private var latestSharedSecret: ByteArray? = null
+    private var latestExchangeHash: ByteArray? = null
+
+    private val rekeyRequestChannel = Channel<Unit>(Channel.UNLIMITED)
+
+    fun start() {
+        scope.launch { serve() }
+    }
+
+    /**
+     * Request that the server initiate a re-key. The re-key will happen when
+     * the server receives the next packet from the client (or when sendIgnore is called).
+     */
+    fun initiateRekey() {
+        rekeyRequestChannel.trySend(Unit)
+    }
+
+    fun sendIgnore() {
+        scope.launch {
+            val msg = org.connectbot.sshlib.protocol.SshMsgIgnore().apply {
+                setData(createByteString(byteArrayOf()))
+                _check()
+            }
+            writeMutex.withLock {
+                serverIo.writePacket(SshEnums.MessageType.SSH_MSG_IGNORE.id().toInt(), msg.toByteArray())
+            }
+        }
+    }
+
+    private suspend fun serve() {
+        serverIo = PacketIO(serverTransport)
+
+        serverIo.writeBanner(serverVersionStr)
+        val clientBanner = serverIo.readBanner()
+        clientVersionStr = "SSH-" + clientBanner.protoVersion().trimEnd('\r', '\n')
+
+        // Initial KEX: reads directly from serverIo (no reader coroutine yet)
+        doFullKex(serverIo)
+
+        // Service request
+        readPacketRaw(serverIo)
+        sendServiceAccept(serverIo)
+
+        // After authentication, all packets are routed through this channel by the reader
+        // coroutine. This ensures there is only one concurrent reader of serverIo at all
+        // times, even during re-key.
+        val incomingPackets = Channel<Pair<SshEnums.MessageType, ByteArray>>(Channel.UNLIMITED)
+        val readerJob = scope.launch {
+            try {
+                while (true) {
+                    incomingPackets.send(readPacketWithType(serverIo))
+                }
+            } catch (_: Exception) {
+                incomingPackets.close()
+            }
+        }
+
+        // Main loop
+        while (true) {
+            val done = select {
+                rekeyRequestChannel.onReceive {
+                    // Server-initiated rekey: send KEXINIT to client now; read from incomingPackets
+                    doServerInitiatedKex(serverIo, incomingPackets)
+                    false
+                }
+                incomingPackets.onReceiveCatching { result ->
+                    val (msgType, rawBytes) = result.getOrNull() ?: return@onReceiveCatching true
+                    when (msgType) {
+                        SshEnums.MessageType.SSH_MSG_KEXINIT ->
+                            doClientInitiatedKex(serverIo, rawBytes, incomingPackets)
+
+                        SshEnums.MessageType.SSH_MSG_DISCONNECT -> return@onReceiveCatching true
+
+                        else -> { /* ignore */ }
+                    }
+                    false
+                }
+            }
+            if (done) break
+        }
+        readerJob.cancel()
+    }
+
+    private suspend fun doFullKex(io: PacketIO) {
+        val serverKexInitBytes = sendKexInit(io)
+        val clientKexInitRaw = readPacketRaw(io)
+        val ecdhInitRaw = readPacketRaw(io)
+        val clientPublic = parseEcdhInit(ecdhInitRaw)
+        sendEcdhReply(io, clientKexInitRaw, serverKexInitBytes, clientPublic)
+        writeMutex.withLock { io.writePacket(SshEnums.MessageType.SSH_MSG_NEWKEYS.id().toInt()) }
+        readPacketRaw(io) // client NEWKEYS
+        activateEncryption(io)
+    }
+
+    private suspend fun doServerInitiatedKex(
+        io: PacketIO,
+        packets: Channel<Pair<SshEnums.MessageType, ByteArray>>,
+    ) {
+        val serverKexInitBytes = sendKexInit(io)
+        // After sending KEXINIT, wait for the client to send its KEXINIT
+        val (firstType, firstRaw) = packets.receive()
+        val clientKexInitRaw = if (firstType == SshEnums.MessageType.SSH_MSG_KEXINIT) {
+            firstRaw
+        } else {
+            // Discard non-kexinit messages until we get KEXINIT
+            var raw = firstRaw
+            var type = firstType
+            while (type != SshEnums.MessageType.SSH_MSG_KEXINIT) {
+                val (t, r) = packets.receive()
+                type = t
+                raw = r
+            }
+            raw
+        }
+        val (_, ecdhInitRaw) = packets.receive() // ECDH_INIT
+        val clientPublic = parseEcdhInit(ecdhInitRaw)
+        sendEcdhReply(io, clientKexInitRaw, serverKexInitBytes, clientPublic)
+        writeMutex.withLock { io.writePacket(SshEnums.MessageType.SSH_MSG_NEWKEYS.id().toInt()) }
+        packets.receive() // client NEWKEYS
+        activateEncryption(io)
+        rekeyCount++
+    }
+
+    private suspend fun doClientInitiatedKex(
+        io: PacketIO,
+        clientKexInitRaw: ByteArray,
+        packets: Channel<Pair<SshEnums.MessageType, ByteArray>>,
+    ) {
+        val serverKexInitBytes = sendKexInit(io)
+        val (_, ecdhInitRaw) = packets.receive() // ECDH_INIT
+        val clientPublic = parseEcdhInit(ecdhInitRaw)
+        sendEcdhReply(io, clientKexInitRaw, serverKexInitBytes, clientPublic)
+        writeMutex.withLock { io.writePacket(SshEnums.MessageType.SSH_MSG_NEWKEYS.id().toInt()) }
+        packets.receive() // client NEWKEYS
+        activateEncryption(io)
+        rekeyCount++
+    }
+
+    private suspend fun sendKexInit(io: PacketIO): ByteArray {
+        val cookie = ByteArray(16).also { SecureRandom().nextBytes(it) }
+
+        val kexInit = SshMsgKexinit().apply {
+            setCookie(cookie)
+            setKexAlgorithms(createNameList("curve25519-sha256"))
+            setServerHostKeyAlgorithms(createNameList("ssh-ed25519"))
+            setEncryptionAlgorithmsClientToServer(createNameList("aes128-ctr"))
+            setEncryptionAlgorithmsServerToClient(createNameList("aes128-ctr"))
+            setMacAlgorithmsClientToServer(createNameList("hmac-sha2-256"))
+            setMacAlgorithmsServerToClient(createNameList("hmac-sha2-256"))
+            setCompressionAlgorithmsClientToServer(createNameList("none"))
+            setCompressionAlgorithmsServerToClient(createNameList("none"))
+            setLanguagesClientToServer(createNameList(""))
+            setLanguagesServerToClient(createNameList(""))
+            setFirstKexPacketFollows(0)
+            setReserved(0)
+            _check()
+        }
+
+        val payload = kexInit.toByteArray()
+        val rawBytes = byteArrayOf(SshEnums.MessageType.SSH_MSG_KEXINIT.id().toByte()) + payload
+        writeMutex.withLock { io.writePacket(SshEnums.MessageType.SSH_MSG_KEXINIT.id().toInt(), payload) }
+        return rawBytes
+    }
+
+    private suspend fun sendEcdhReply(
+        io: PacketIO,
+        clientKexInitRaw: ByteArray,
+        serverKexInitBytes: ByteArray,
+        clientPublic: ByteArray,
+    ) {
+        val x25519 = X25519ProviderFactory.provider
+        val serverPrivate = x25519.generatePrivateKey()
+        val serverPublic = x25519.publicFromPrivate(serverPrivate)
+
+        val sharedSecretRaw = x25519.computeSharedSecret(serverPrivate, clientPublic)
+        val sharedSecret = encodeMpint(BigInteger(1, sharedSecretRaw).toByteArray())
+
+        val exchangeHash = computeExchangeHash(
+            clientVersion = clientVersionStr.toByteArray(Charsets.US_ASCII),
+            serverVersion = serverVersionStr.toByteArray(Charsets.US_ASCII),
+            clientKexInit = clientKexInitRaw,
+            serverKexInit = serverKexInitBytes,
+            serverHostKey = hostKeyBlob,
+            clientPublicKey = clientPublic,
+            serverPublicKey = serverPublic,
+            sharedSecret = sharedSecret,
+        )
+
+        latestSharedSecret = sharedSecret
+        latestExchangeHash = exchangeHash
+        if (sessionId == null) {
+            sessionId = exchangeHash
+        }
+
+        val signature = signExchangeHash(exchangeHash)
+        val signatureBlob = buildSignatureBlob(signature)
+
+        val reply = SshMsgKexEcdhReply().apply {
+            setKS(createByteString(hostKeyBlob))
+            setQS(createByteString(serverPublic))
+            setSignatureH(createByteString(signatureBlob))
+            _check()
+        }
+
+        writeMutex.withLock { io.writePacket(SshEnums.KexEcdh.SSH_MSG_KEX_ECDH_REPLY.id().toInt(), reply.toByteArray()) }
+    }
+
+    private fun activateEncryption(io: PacketIO) {
+        val sharedSecret = latestSharedSecret ?: return
+        val exchangeHash = latestExchangeHash ?: return
+        val sid = sessionId ?: return
+
+        val keyDerivation = KeyDerivation(sharedSecret, exchangeHash, sid, "SHA-256")
+        val cipherEntry = CipherEntry.fromSshName("aes128-ctr") ?: return
+        val macEntry = MacEntry.fromSshName("hmac-sha2-256") ?: return
+
+        val keys = keyDerivation.deriveKeys(
+            ivLength = cipherEntry.ivLength,
+            keyLength = cipherEntry.keyLength,
+            macKeyLength = macEntry.keyLength,
+        )
+
+        val c2sKey = keys.encryptionKeyClientToServer.copyOf(cipherEntry.keyLength)
+        val s2cKey = keys.encryptionKeyServerToClient.copyOf(cipherEntry.keyLength)
+        val c2sIv = keys.initialIvClientToServer.copyOf(cipherEntry.ivLength)
+        val s2cIv = keys.initialIvServerToClient.copyOf(cipherEntry.ivLength)
+
+        // Server RECEIVES with C2S key (client encrypts, server decrypts with decrypt=false)
+        val receiveCipher = (cipherEntry.create(c2sKey, c2sIv, false) as EncryptionInstance.Cipher).cipher
+        // Server SENDS with S2C key (server encrypts, client decrypts)
+        val sendCipher = (cipherEntry.create(s2cKey, s2cIv, true) as EncryptionInstance.Cipher).cipher
+
+        val receiveMac = macEntry.create(keys.integrityKeyClientToServer)
+        val sendMac = macEntry.create(keys.integrityKeyServerToClient)
+
+        // PacketIO.enableEncryption parameters (from client perspective):
+        //   clientToServerCipher -> PacketIO.sendCipher
+        //   serverToClientCipher -> PacketIO.receiveCipher
+        // For server: pass sendCipher as clientToServer, receiveCipher as serverToClient
+        io.enableEncryption(
+            clientToServerCipher = sendCipher,
+            clientToServerMac = sendMac,
+            serverToClientCipher = receiveCipher,
+            serverToClientMac = receiveMac,
+        )
+    }
+
+    private fun computeExchangeHash(
+        clientVersion: ByteArray,
+        serverVersion: ByteArray,
+        clientKexInit: ByteArray,
+        serverKexInit: ByteArray,
+        serverHostKey: ByteArray,
+        clientPublicKey: ByteArray,
+        serverPublicKey: ByteArray,
+        sharedSecret: ByteArray,
+    ): ByteArray {
+        val md = MessageDigest.getInstance("SHA-256")
+        val buf = java.io.ByteArrayOutputStream()
+
+        fun writeString(data: ByteArray) {
+            val len = data.size
+            buf.write(ByteBuffer.allocate(4).putInt(len).array())
+            buf.write(data)
+        }
+
+        writeString(clientVersion)
+        writeString(serverVersion)
+        writeString(clientKexInit)
+        writeString(serverKexInit)
+        writeString(serverHostKey)
+        writeString(clientPublicKey)
+        writeString(serverPublicKey)
+        buf.write(sharedSecret)
+
+        return md.digest(buf.toByteArray())
+    }
+
+    private fun signExchangeHash(hash: ByteArray): ByteArray {
+        val signer = java.security.Signature.getInstance("Ed25519")
+        signer.initSign(hostKeyPair.private)
+        signer.update(hash)
+        return signer.sign()
+    }
+
+    private fun buildSignatureBlob(signature: ByteArray): ByteArray {
+        val algBytes = "ssh-ed25519".toByteArray(Charsets.US_ASCII)
+        val out = java.io.ByteArrayOutputStream()
+        out.write(ByteBuffer.allocate(4).putInt(algBytes.size).array())
+        out.write(algBytes)
+        out.write(ByteBuffer.allocate(4).putInt(signature.size).array())
+        out.write(signature)
+        return out.toByteArray()
+    }
+
+    private suspend fun sendServiceAccept(io: PacketIO) {
+        val msg = SshMsgServiceAccept().apply {
+            setServiceName(createAsciiString("ssh-userauth"))
+            _check()
+        }
+        io.writePacket(SshEnums.MessageType.SSH_MSG_SERVICE_ACCEPT.id().toInt(), msg.toByteArray())
+    }
+
+    private suspend fun readPacketRaw(io: PacketIO): ByteArray {
+        val packet = io.readPacket()
+        return byteArrayOf(packet.messageType().id().toByte()) + packet._raw_body()
+    }
+
+    private suspend fun readPacketWithType(io: PacketIO): Pair<SshEnums.MessageType, ByteArray> {
+        val packet = io.readPacket()
+        val msgType = packet.messageType()
+        val rawBytes = byteArrayOf(msgType.id().toByte()) + packet._raw_body()
+        return msgType to rawBytes
+    }
+
+    private fun parseEcdhInit(rawBytes: ByteArray): ByteArray {
+        val bodyBytes = rawBytes.copyOfRange(1, rawBytes.size)
+        val stream = ByteBufferKaitaiStream(bodyBytes)
+        val msg = SshMsgKexEcdhInit(stream)
+        msg._read()
+        return msg.qC().data()
+    }
+}

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/client/RekeyTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/client/RekeyTest.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.client
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import org.connectbot.sshlib.ConnectResult
+import org.connectbot.sshlib.HostKeyVerifier
+import org.connectbot.sshlib.PublicKey
+import org.connectbot.sshlib.transport.PipedTransport
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RekeyTest {
+
+    private val acceptAllVerifier = object : HostKeyVerifier {
+        override suspend fun verify(key: PublicKey): Boolean = true
+    }
+
+    @Test
+    fun `rekey triggered when byte limit exceeded`() = runTest {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val (clientTransport, serverTransport) = PipedTransport.create()
+        val server = FakeSshServer(serverTransport, scope)
+        server.start()
+
+        val connection = SshConnection(
+            transport = clientTransport,
+            hostKeyVerifier = acceptAllVerifier,
+            rekeyBytesLimit = 512L,
+            rekeyIntervalMs = Long.MAX_VALUE,
+        )
+
+        try {
+            val result = withContext(Dispatchers.Default) { connection.connect() }
+            assertIs<ConnectResult.Success>(result)
+
+            server.sendIgnore()
+            withContext(Dispatchers.Default) {
+                withTimeout(5_000L) {
+                    while (server.rekeyCount < 1) delay(50)
+                }
+            }
+
+            assertTrue(server.rekeyCount >= 1)
+
+            // Verify connection is still alive after re-key
+            server.sendIgnore()
+            withContext(Dispatchers.Default) { delay(200) }
+        } finally {
+            connection.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `rekey triggered after interval elapses`() = runTest {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val (clientTransport, serverTransport) = PipedTransport.create()
+        val server = FakeSshServer(serverTransport, scope)
+        server.start()
+
+        val connection = SshConnection(
+            transport = clientTransport,
+            hostKeyVerifier = acceptAllVerifier,
+            rekeyIntervalMs = 3_600_000L,
+            rekeyBytesLimit = Long.MAX_VALUE,
+            coroutineContext = dispatcher,
+        )
+
+        try {
+            val result = withContext(Dispatchers.Default) { connection.connect() }
+            assertIs<ConnectResult.Success>(result)
+
+            assertEquals(0, server.rekeyCount)
+
+            advanceTimeBy(3_600_001L)
+
+            server.sendIgnore()
+            withContext(Dispatchers.Default) {
+                withTimeout(5_000L) {
+                    while (server.rekeyCount < 1) delay(50)
+                }
+            }
+
+            assertEquals(1, server.rekeyCount)
+        } finally {
+            connection.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `server-initiated rekey is handled correctly`() = runTest {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val (clientTransport, serverTransport) = PipedTransport.create()
+        val server = FakeSshServer(serverTransport, scope)
+        server.start()
+
+        val connection = SshConnection(
+            transport = clientTransport,
+            hostKeyVerifier = acceptAllVerifier,
+            rekeyIntervalMs = Long.MAX_VALUE,
+            rekeyBytesLimit = Long.MAX_VALUE,
+        )
+
+        try {
+            val result = withContext(Dispatchers.Default) { connection.connect() }
+            assertIs<ConnectResult.Success>(result)
+
+            server.initiateRekey()
+            withContext(Dispatchers.Default) {
+                withTimeout(5_000L) {
+                    while (server.rekeyCount < 1) delay(50)
+                }
+            }
+
+            assertEquals(1, server.rekeyCount)
+        } finally {
+            connection.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `packets received during rekey are not dropped`() = runTest {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val (clientTransport, serverTransport) = PipedTransport.create()
+        val server = FakeSshServer(serverTransport, scope)
+        server.start()
+
+        val connection = SshConnection(
+            transport = clientTransport,
+            hostKeyVerifier = acceptAllVerifier,
+            rekeyIntervalMs = Long.MAX_VALUE,
+            rekeyBytesLimit = Long.MAX_VALUE,
+        )
+
+        try {
+            val result = withContext(Dispatchers.Default) { connection.connect() }
+            assertIs<ConnectResult.Success>(result)
+
+            server.sendIgnore()
+            server.initiateRekey()
+            server.sendIgnore()
+            withContext(Dispatchers.Default) {
+                withTimeout(5_000L) {
+                    while (server.rekeyCount < 1) delay(50)
+                }
+            }
+
+            assertEquals(1, server.rekeyCount)
+
+            // Packet processing should continue after re-key with no disconnect.
+            server.sendIgnore()
+            withContext(Dispatchers.Default) { delay(200) }
+            val disconnectCause = withTimeoutOrNull(250) { connection.disconnectedFlow.first() }
+            assertNull(disconnectCause)
+        } finally {
+            connection.close()
+            scope.cancel()
+        }
+    }
+}

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SshClientIntegrationTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/client/SshClientIntegrationTest.kt
@@ -699,6 +699,48 @@ class SshClientIntegrationTest {
     }
 
     @Test
+    fun `rekey occurs when byte limit is exceeded`() = runBlocking {
+        val host = opensshContainer.host
+        val port = opensshContainer.getMappedPort(22)
+
+        val config = SshClientConfig {
+            this.host = host
+            this.port = port
+            this.hostKeyVerifier = acceptAllVerifier
+            // Keep this above handshake/auth traffic so re-key is triggered by session data.
+            this.rekeyBytesLimit = 8_192L
+            this.rekeyIntervalMs = Long.MAX_VALUE
+        }
+        val client = SshClient(config)
+
+        try {
+            val result = withTimeout(30_000) { client.connect() }
+            assertTrue(result is ConnectResult.Success, "Should connect to SSH server")
+            assertTrue(client.authenticatePassword(USERNAME, PASSWORD) is AuthResult.Success, "Should authenticate")
+
+            val session = client.openSession()
+            assertNotNull(session)
+
+            val execResult = session!!.requestExec("dd if=/dev/urandom bs=1024 count=64 2>/dev/null | base64")
+            assertTrue(execResult, "Should successfully request exec")
+
+            val output = withTimeout(10_000) {
+                val buf = StringBuilder()
+                while (true) {
+                    val data = session.read() ?: break
+                    buf.append(String(data))
+                }
+                buf.toString()
+            }
+
+            assertTrue(output.length > 1_024, "Should receive enough output to cross rekey threshold")
+            session.close()
+        } finally {
+            client.disconnect()
+        }
+    }
+
+    @Test
     fun `should open sftp subsystem and exchange version`() = runBlocking {
         val host = opensshContainer.host
         val port = opensshContainer.getMappedPort(22)

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/transport/PacketIOTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/transport/PacketIOTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.runBlocking
 import org.connectbot.sshlib.protocol.SshEnums
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer
 
@@ -115,5 +116,55 @@ class PacketIOTest {
 
         io.resetSendSequenceNumber()
         io.resetReceiveSequenceNumber()
+    }
+
+    @Test
+    fun `bytesSentOnWire tracks unencrypted write`() = runBlocking {
+        val transport = ByteArrayTransport()
+        val io = PacketIO(transport)
+
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val payload = ByteBuffer.allocate(4 + data.size)
+            .putInt(data.size)
+            .put(data)
+            .array()
+        io.writePacket(SshEnums.MessageType.SSH_MSG_IGNORE.id().toInt(), payload)
+        assertTrue(io.bytesSentOnWire > 0)
+        assertEquals(io.bytesSentOnWire, transport.getWrittenData().size.toLong())
+    }
+
+    @Test
+    fun `bytesReceivedOnWire tracks unencrypted read`() = runBlocking {
+        val transport = ByteArrayTransport()
+        val writer = PacketIO(transport)
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val payload = ByteBuffer.allocate(4 + data.size)
+            .putInt(data.size)
+            .put(data)
+            .array()
+        writer.writePacket(SshEnums.MessageType.SSH_MSG_IGNORE.id().toInt(), payload)
+
+        val readTransport = ByteArrayTransport(transport.getWrittenData())
+        val reader = PacketIO(readTransport)
+        reader.readPacket()
+
+        assertEquals(transport.getWrittenData().size.toLong(), reader.bytesReceivedOnWire)
+    }
+
+    @Test
+    fun `resetByteCounters zeroes both counters`() = runBlocking {
+        val transport = ByteArrayTransport()
+        val io = PacketIO(transport)
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val payload = ByteBuffer.allocate(4 + data.size)
+            .putInt(data.size)
+            .put(data)
+            .array()
+        io.writePacket(SshEnums.MessageType.SSH_MSG_IGNORE.id().toInt(), payload)
+        assertTrue(io.bytesSentOnWire > 0)
+
+        io.resetByteCounters()
+        assertEquals(0L, io.bytesSentOnWire)
+        assertEquals(0L, io.bytesReceivedOnWire)
     }
 }

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/transport/PipedTransport.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/transport/PipedTransport.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.connectbot.sshlib.transport
+
+import kotlinx.coroutines.channels.Channel
+import java.io.IOException
+
+class PipedTransport private constructor(
+    private val inbound: Channel<ByteArray>,
+    private val outbound: Channel<ByteArray>,
+) : Transport {
+
+    companion object {
+        fun create(): Pair<PipedTransport, PipedTransport> {
+            val aToB = Channel<ByteArray>(Channel.UNLIMITED)
+            val bToA = Channel<ByteArray>(Channel.UNLIMITED)
+            return PipedTransport(bToA, aToB) to PipedTransport(aToB, bToA)
+        }
+    }
+
+    private val readBuffer = ArrayDeque<Byte>()
+
+    @Volatile
+    private var closed = false
+
+    override suspend fun read(count: Int): ByteArray {
+        while (readBuffer.size < count) {
+            val chunk = try {
+                inbound.receive()
+            } catch (_: kotlinx.coroutines.channels.ClosedReceiveChannelException) {
+                throw java.io.IOException("Transport closed")
+            }
+            readBuffer.addAll(chunk.toList())
+        }
+        return ByteArray(count) { readBuffer.removeFirst() }
+    }
+
+    override suspend fun write(data: ByteArray) {
+        if (closed) throw IOException("Transport closed")
+        outbound.send(data)
+    }
+
+    override suspend fun close() {
+        closed = true
+        outbound.close()
+    }
+
+    override val isConnected: Boolean get() = !closed
+}


### PR DESCRIPTION
Migrate KEX flow to use the state machine instead of calls in connect(). Use the newly migrated states to implement rekeying support. Add configuration to rekey after a certain number of milliseconds or byte limits.

In order to test, make a FakeSshServer to test against. I imagine this will grow into a larger full-fledged server in the future.