### PR TITLE
chore(KtorTcpTransport): add way to get localSocketAddress

### DIFF
--- a/sshlib/api.txt
+++ b/sshlib/api.txt
@@ -791,6 +791,7 @@ package org.connectbot.sshlib.transport {
     ctor public KtorTcpTransport(java.lang.String host, optional int port, optional org.connectbot.sshlib.transport.IpVersion ipVersion);
     method public suspend java.lang.Object? close(kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend java.lang.Object? connect(kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public java.net.InetSocketAddress? getLocalAddress();
     method @InaccessibleFromKotlin public boolean isConnected();
     method public suspend java.lang.Object? read(int count, kotlin.coroutines.Continuation<? super byte[]>);
     method public suspend java.lang.Object? write(byte[] data, kotlin.coroutines.Continuation<? super kotlin.Unit>);

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/transport/KtorTcpTransport.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/transport/KtorTcpTransport.kt
@@ -70,6 +70,12 @@ class KtorTcpTransport internal constructor(
         get() = socket?.isClosed == false
 
     /**
+     * Local TCP address assigned to the connected socket, or `null` before
+     * connection, after close, or when the injected socket does not expose it.
+     */
+    fun getLocalAddress(): java.net.InetSocketAddress? = (socket as? LocalAddressProvider)?.localAddress
+
+    /**
      * Connect to the remote host.
      * Must be called before any read/write operations.
      */

--- a/sshlib/src/main/kotlin/org/connectbot/sshlib/transport/TransportDependencies.kt
+++ b/sshlib/src/main/kotlin/org/connectbot/sshlib/transport/TransportDependencies.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.Closeable
 import java.net.InetAddress
+import java.net.InetSocketAddress as JavaInetSocketAddress
 
 /**
  * Resolves hostnames to IP addresses.
@@ -43,6 +44,10 @@ interface TransportSocket : Closeable {
     val isClosed: Boolean
     fun openReadChannel(): ByteReadChannel
     fun openWriteChannel(autoFlush: Boolean = false): ByteWriteChannel
+}
+
+internal interface LocalAddressProvider {
+    val localAddress: JavaInetSocketAddress?
 }
 
 /**
@@ -68,9 +73,14 @@ internal class KtorTcpSocketFactory(
     }
 }
 
-private class KtorTransportSocket(private val socket: Socket) : TransportSocket {
+private class KtorTransportSocket(private val socket: Socket) :
+    TransportSocket,
+    LocalAddressProvider {
     override val isClosed: Boolean
         get() = socket.isClosed
+
+    override val localAddress: JavaInetSocketAddress?
+        get() = (socket.localAddress as? InetSocketAddress)?.toJavaInetSocketAddress()
 
     override fun openReadChannel(): ByteReadChannel = socket.openReadChannel()
 
@@ -79,4 +89,10 @@ private class KtorTransportSocket(private val socket: Socket) : TransportSocket 
     override fun close() {
         socket.close()
     }
+}
+
+private fun InetSocketAddress.toJavaInetSocketAddress(): JavaInetSocketAddress = runCatching {
+    JavaInetSocketAddress(InetAddress.getByAddress(hostname, resolveAddress()), port)
+}.getOrElse {
+    JavaInetSocketAddress.createUnresolved(hostname, port)
 }

--- a/sshlib/src/test/kotlin/org/connectbot/sshlib/transport/KtorTcpTransportTest.kt
+++ b/sshlib/src/test/kotlin/org/connectbot/sshlib/transport/KtorTcpTransportTest.kt
@@ -24,8 +24,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.net.InetAddress
+import java.net.InetSocketAddress
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -45,6 +47,27 @@ class KtorTcpTransportTest {
         assertTrue(transport.isConnected)
         assertEquals(1, factory.connectionAttempts.size)
         assertEquals(addr, factory.connectionAttempts[0])
+    }
+
+    @Test
+    fun `local address is exposed for connected socket`() = runTest {
+        val addr = InetAddress.getByName("127.0.0.1")
+        val localAddress = InetSocketAddress(InetAddress.getByName("192.0.2.10"), 54321)
+        val socket = MockSocket(localAddress)
+
+        val resolver = MockAddressResolver(mapOf("example.com" to listOf(addr)))
+        val factory = MockTcpSocketFactory(mapOf(addr to { socket }))
+
+        val transport = KtorTcpTransport("example.com", 22, resolver, factory)
+
+        assertNull(transport.getLocalAddress())
+        transport.connect()
+
+        assertEquals(localAddress, transport.getLocalAddress())
+
+        transport.close()
+
+        assertNull(transport.getLocalAddress())
     }
 
     @Test
@@ -266,7 +289,10 @@ class MockTcpSocketFactory(
     }
 }
 
-class MockSocket : TransportSocket {
+class MockSocket(
+    override val localAddress: InetSocketAddress? = null,
+) : TransportSocket,
+    LocalAddressProvider {
     private var closed = false
 
     override fun close() {


### PR DESCRIPTION
This is needed for connection tracking in ConnectBot. If the local address for the socket is indicated in a network event, ConnectBot will either wait for it to come back or disconnect immediately.